### PR TITLE
Changed ^ to ** in comments

### DIFF
--- a/src/cwrapper.h
+++ b/src/cwrapper.h
@@ -77,7 +77,7 @@ void basic_sub(basic s, const basic a, const basic b);
 void basic_mul(basic s, const basic a, const basic b);
 //! Assigns s = a / b.
 void basic_div(basic s, const basic a, const basic b);
-//! Assigns s = a ^ b.
+//! Assigns s = a ** b.
 void basic_pow(basic s, const basic a, const basic b);
 //! Assign to s, derivative of expr with respect to sym. Returns 0 if sym is not a symbol.
 int basic_diff(basic s, const basic expr, const basic sym);

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -337,7 +337,7 @@ RCP<const Basic> det_berkowitz(const DenseMatrix &A);
 
 // Characteristic polynomial: Only the coefficients of monomials in decreasing
 // order of monomial powers is returned, i.e. if `B = transpose([1, -2, 3])`
-// then the corresponding polynomial is `x^2 - 2x + 3`.
+// then the corresponding polynomial is `x**2 - 2x + 3`.
 void char_poly(const DenseMatrix &A, DenseMatrix &B);
 
 // Mimic `eye` function in NumPy

--- a/src/mul.cpp
+++ b/src/mul.cpp
@@ -25,35 +25,35 @@ bool Mul::is_canonical(const RCP<const Number> &coef,
         return false;
     if (dict.size() == 0) return false;
     if (dict.size() == 1) {
-        // e.g. 1*x, 1*x^2
+        // e.g. 1*x, 1*x**2
         if (coef->is_one()) return false;
     }
     // Check that each term in 'dict' is in canonical form
     for (auto &p: dict) {
         if (p.first == null) return false;
         if (p.second == null) return false;
-        // e.g. 2^3, (2/3)^4
+        // e.g. 2**3, (2/3)**4
         // However for Complex no simplification is done
         if ((is_a<Integer>(*p.first) || is_a<Rational>(*p.first))
             && is_a<Integer>(*p.second))
             return false;
-        // e.g. 0^x
+        // e.g. 0**x
         if (is_a<Integer>(*p.first) &&
                 rcp_static_cast<const Integer>(p.first)->is_zero())
             return false;
-        // e.g. 1^x
+        // e.g. 1**x
         if (is_a<Integer>(*p.first) &&
                 rcp_static_cast<const Integer>(p.first)->is_one())
             return false;
-        // e.g. x^0
+        // e.g. x**0
         if (is_a<Integer>(*p.second) &&
                 rcp_static_cast<const Integer>(p.second)->is_zero())
             return false;
-        // e.g. (x*y)^2 (={xy:2}), which should be represented as x^2*y^2
+        // e.g. (x*y)**2 (={xy:2}), which should be represented as x**2*y**2
         //     (={x:2, y:2})
         if (is_a<Mul>(*p.first))
             return false;
-        // e.g. x^2^y (={x^2:y}), which should be represented as x^(2y)
+        // e.g. x**2**y (={x**2:y}), which should be represented as x**(2y)
         //     (={x:2y})
         if (is_a<Pow>(*p.first))
             return false;
@@ -109,11 +109,11 @@ RCP<const SymEngine::Basic> Mul::from_dict(const RCP<const Number> &coef, map_ba
         if (is_a<Integer>(*(p->second))) {
             if (coef->is_one()) {
                 if ((rcp_static_cast<const Integer>(p->second))->is_one()) {
-                    // For x^1 we simply return "x":
+                    // For x**1 we simply return "x":
                     return p->first;
                 }
             } else {
-                // For coef*x or coef*x^3 we simply return Mul:
+                // For coef*x or coef*x**3 we simply return Mul:
                 return rcp(new Mul(coef, std::move(d)));
             }
         }
@@ -128,7 +128,7 @@ RCP<const SymEngine::Basic> Mul::from_dict(const RCP<const Number> &coef, map_ba
     }
 }
 
-// Mul (t^exp) to the dict "d"
+// Mul (t**exp) to the dict "d"
 void Mul::dict_add_term(map_basic_basic &d, const RCP<const Basic> &exp,
         const RCP<const Basic> &t)
 {
@@ -156,7 +156,7 @@ void Mul::dict_add_term(map_basic_basic &d, const RCP<const Basic> &exp,
     }
 }
 
-// Mul (t^exp) to the dict "d"
+// Mul (t**exp) to the dict "d"
 void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic &d,
     const RCP<const Basic> &exp, const RCP<const Basic> &t)
 {
@@ -247,7 +247,7 @@ void Mul::dict_add_term_new(const Ptr<RCP<const Number>> &coef, map_basic_basic 
 void Mul::as_two_terms(const Ptr<RCP<const Basic>> &a,
             const Ptr<RCP<const Basic>> &b) const
 {
-    // Example: if this=3*x^2*y^2*z^2, then a=x^2 and b=3*y^2*z^2
+    // Example: if this=3*x**2*y**2*z**2, then a=x**2 and b=3*y**2*z**2
     auto p = dict_.begin();
     *a = pow(p->first, p->second);
     map_basic_basic d = dict_;
@@ -350,7 +350,7 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
         RCP<const Number> coef = mulnum(rcp_static_cast<const Add>(a)->coef_,
             rcp_static_cast<const Add>(b)->coef_);
         umap_basic_num d;
-        // Improves (x+1)^3(x+2)^3...(x+350)^3 expansion from 0.97s to 0.93s:
+        // Improves (x+1)**3*(x+2)**3*...(x+350)**3 expansion from 0.97s to 0.93s:
         d.reserve((rcp_static_cast<const Add>(a))->dict_.size()*
             (rcp_static_cast<const Add>(b))->dict_.size());
         // Expand dicts first:

--- a/src/mul.h
+++ b/src/mul.h
@@ -45,7 +45,7 @@ public:
             const Ptr<RCP<const Basic>> &base);
     //! Rewrite as 2 terms
     /*!
-        Example: if this=3*x^2*y^2*z^2`, then `a=x^2` and `b=3*y^2*z^2`
+        Example: if this=3*x**2*y**2*z**2`, then `a=x**2` and `b=3*y**2*z**2`
     * */
     void as_two_terms(const Ptr<RCP<const Basic>> &a,
             const Ptr<RCP<const Basic>> &b) const;

--- a/src/ntheory.cpp
+++ b/src/ntheory.cpp
@@ -643,7 +643,7 @@ bool crt(const Ptr<RCP<const Integer>> &R, const std::vector<RCP<const Integer>>
         t = rem[i]->as_mpz() - r;
         if (!mpz_divisible_p (t.get_mpz_t(), g.get_mpz_t()))
             return false;
-        r += m * s * (t / g);           // r += m * (m^-1 mod[i]/g)* (rem[i] - r) / g
+        r += m * s * (t / g);           // r += m * (m**-1 mod[i]/g)* (rem[i] - r) / g
         m *= mod[i]->as_mpz() / g;
         mpz_fdiv_r (r.get_mpz_t(), r.get_mpz_t(), m.get_mpz_t());
     }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -21,36 +21,36 @@ bool Pow::is_canonical(const RCP<const Basic> &base, const RCP<const Basic> &exp
 {
     if (base == null) return false;
     if (exp == null) return false;
-    // e.g. 0^x
+    // e.g. 0**x
     if (is_a<Integer>(*base) && rcp_static_cast<const Integer>(base)->is_zero())
         return false;
-    // e.g. 1^x
+    // e.g. 1**x
     if (is_a<Integer>(*base) && rcp_static_cast<const Integer>(base)->is_one())
         return false;
-    // e.g. x^0
+    // e.g. x**0
     if (is_a<Integer>(*exp) && rcp_static_cast<const Integer>(exp)->is_zero())
         return false;
-    // e.g. x^1
+    // e.g. x**1
     if (is_a<Integer>(*exp) && rcp_static_cast<const Integer>(exp)->is_one())
         return false;
-    // e.g. 2^3, (2/3)^4
+    // e.g. 2**3, (2/3)**4
     if ((is_a<Integer>(*base) || is_a<Rational>(*base)) && is_a<Integer>(*exp))
         return false;
-    // e.g. (x*y)^2, should rather be x^2*y^2
+    // e.g. (x*y)**2, should rather be x**2*y**2
     if (is_a<Mul>(*base) && is_a<Integer>(*exp))
         return false;
-    // e.g. (x^y)^2, should rather be x^(2*y)
+    // e.g. (x**y)**2, should rather be x**(2*y)
     if (is_a<Pow>(*base) && is_a<Integer>(*exp))
         return false;
     // If exp is a rational, it should be between 0  and 1, i.e. we don't
-    // allow things like 2^(-1/2) or 2^(3/2)
+    // allow things like 2**(-1/2) or 2**(3/2)
     if ((is_a<Rational>(*base) || is_a<Integer>(*base)) &&
         is_a<Rational>(*exp) &&
         (rcp_static_cast<const Rational>(exp)->i < 0 ||
         rcp_static_cast<const Rational>(exp)->i > 1))
         return false;
     // Purely Imaginary complex numbers with integral powers are expanded
-    // e.g (2I)^3
+    // e.g (2I)**3
     if (is_a<Complex>(*base) && rcp_static_cast<const Complex>(base)->is_re_zero() &&
         is_a<Integer>(*exp))
         return false;
@@ -167,12 +167,12 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
         }
     }
     if (is_a<Mul>(*a) && is_a<Integer>(*b)) {
-        // Convert (x*y)^b = x^b*y^b, where 'b' is an integer. This holds for
+        // Convert (x*y)**b = x**b*y**b, where 'b' is an integer. This holds for
         // any complex 'x', 'y' and integer 'b'.
         return rcp_static_cast<const Mul>(a)->power_all_terms(b);
     }
     if (is_a<Pow>(*a) && is_a<Integer>(*b)) {
-        // Convert (x^y)^b = x^(b*y), where 'b' is an integer. This holds for
+        // Convert (x**y)**b = x**(b*y), where 'b' is an integer. This holds for
         // any complex 'x', 'y' and integer 'b'.
         RCP<const Pow> A = rcp_static_cast<const Pow>(a);
         return pow(A->base_, mul(A->exp_, b));
@@ -299,7 +299,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
     multinomial_coefficients_mpz(m, n, r);
     umap_basic_num rd;
     // This speeds up overall expansion. For example for the benchmark
-    // (y + x + z + w)^60 it improves the timing from 135ms to 124ms.
+    // (y + x + z + w)**60 it improves the timing from 135ms to 124ms.
     rd.reserve(2*r.size());
     RCP<const Number> add_overall_coeff=zero;
     for (auto &p: r) {

--- a/src/pow.h
+++ b/src/pow.h
@@ -17,7 +17,7 @@ namespace SymEngine {
 
 class Pow : public Basic {
 public: // TODO: make this private
-    RCP<const Basic> base_, exp_; //! base^exp
+    RCP<const Basic> base_, exp_; //! base**exp
 
 public:
     IMPLEMENT_TYPEID(POW)
@@ -34,9 +34,9 @@ public:
     //! \return `true` if canonical
     bool is_canonical(const RCP<const Basic> &base,
             const RCP<const Basic> &exp);
-    //! \return `base` of `base^exp`
+    //! \return `base` of `base**exp`
     inline RCP<const Basic> get_base() const { return base_; }
-    //! \return `exp` of `base^exp`
+    //! \return `exp` of `base**exp`
     inline RCP<const Basic> get_exp() const { return exp_; }
     //! Differentiate w.r.t Symbol `x`
     virtual RCP<const Basic> diff(const RCP<const Symbol> &x) const;
@@ -51,7 +51,7 @@ public:
 RCP<const Basic> pow(const RCP<const Basic> &a,
         const RCP<const Basic> &b);
 
-//! Returns the natural exponential function `E^x = pow(E, x)`
+//! Returns the natural exponential function `E**x = pow(E, x)`
 RCP<const Basic> exp(const RCP<const Basic> &x);
 
 void multinomial_coefficients(int m, int n, map_vec_int &r);

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -394,7 +394,7 @@ void test_pow()
     r2 = zero;
     assert(eq(r1, r2));
 
-    /* Test (x*y)^2 -> x^2*y^2 type of simplifications */
+    /* Test (x*y)**2 -> x**2*y**2 type of simplifications */
 
     r1 = pow(mul(x, y), i2);
     r2 = mul(pow(x, i2), pow(y, i2));


### PR DESCRIPTION
Changed ^ to ** in comments of all source as well as test files, 
so as to maintain uniformity throughout.
The printing of power was previously changed from ^ to ** in https://github.com/sympy/symengine/pull/404.