### PR TITLE
[ci skip] An effort to document: Entry guide to contributors

### DIFF
--- a/doc/symengine.md
+++ b/doc/symengine.md
@@ -1,0 +1,32 @@
+#SymEngine - How Things Work
+
+SymEngine is a fast symbolic manipulation library, written in C++ (SymEngine was previously called CSymPy)
+
+Website for SymPy : http://sympy.org
+
+This document contains information about the decisions made when SymEngine evolved.<br/>
+The plan is this along with [C++ Style Guide](https://github.com/sympy/symengine/blob/master/doc/style_guide.md) and [Design](https://github.com/sympy/symengine/blob/master/doc/design.md) doc should be exhaustive and contain all you need to know to contribute for SymEngine.<br/>
+
+##RCP
+Info about RCP
+
+##Dict
+Info about the dicts used everywhere
+
+##Classes
+Info about basic, other subclasses - about hash, eq<br/>
+
+##Modules
+Provide some specific information if you feel like, for example in ntheory, function, matrix, diophantine etc.
+
+##Evaldouble
+
+##Single dispatch, double dispatch, Visitor patter.
+
+##CWrappers
+
+##CXX, Cython
+
+##Python, Ruby & Julia Wrappers
+
+##Compatablities with SymPy, Improvements and Shortcomings compared to SympY


### PR DESCRIPTION
To improve the documentation of SymEngine, an entry guide to future contributors also to increase understanding of SymEngine as part of GSoC community bonding.
