### PR TITLE
Optionally link tcmalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,5 +233,10 @@ if (WITH_ARB)
     message("MPFR_LIBRARIES: ${MPFR_LIBRARIES}")
 endif()
 
+message("WITH_TCMALLOC: ${WITH_TCMALLOC}")
+if (WITH_TCMALLOC)
+    message("TCMALLOC_LIBRARIES: ${TCMALLOC_LIBRARIES}")
+endif()
+
 message("Copying source of python wrappers into: ${CMAKE_CURRENT_BINARY_DIR}")
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/csympy DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,23 @@ if (WITH_BFD)
     set(LIBS ${LIBS} ${EXECINFO_LIBRARIES})
 endif()
 
+# TCMalloc
+set(WITH_TCMALLOC no
+    CACHE BOOL "Build with TCMalloc linked")
+
+if (WITH_TCMALLOC)
+    find_package(TCMALLOC REQUIRED)
+    set(LIBS ${LIBS} ${TCMALLOC_LIBRARIES})
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_CXX_FLAGS_DEBUG
+            "${CMAKE_CXX_FLAGS_DEBUG} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")
+        set(CMAKE_CXX_FLAGS_RELEASE
+            "${CMAKE_CXX_FLAGS_RELEASE} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")
+    endif()
+
+endif()
+
 # Doxygen
 set(BUILD_DOXYGEN no
     CACHE BOOL "Create C++ API Doxgyen documentation.")

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ their default values indicated below:
         -DWITH_SYMENGINE_RCP:BOOL=ON \                   # Use our faster special implementation of RCP
         -DWITH_PRIMESIEVE=OFF \                       # Install with Primesieve library
         -DWITH_ARB=OFF \                              # Install with ARB library
+        -DWITH_TCMALLOC=OFF \                         # Install with TCMalloc linked
         .
 
 `CMake` prints the value of its options at the end of the run.

--- a/cmake/FindTCMALLOC.cmake
+++ b/cmake/FindTCMALLOC.cmake
@@ -1,0 +1,12 @@
+include(LibFindMacros)
+
+libfind_library(tcmalloc tcmalloc)
+if (NOT TCMALLOC_LIBRARY_FOUND)
+    libfind_library(tcmalloc_minimal tcmalloc)
+    set(TCMALLOC_LIBRARY ${TCMALLOC_MINIMAL_LIBRARY})
+endif()
+set(TCMALLOC_LIBRARIES ${TCMALLOC_LIBRARY})
+find_package_handle_standard_args(TCMALLOC DEFAULT_MSG
+    TCMALLOC_LIBRARIES)
+
+mark_as_advanced(TCMALLOC_LIBRARY TCMALLOC_MINIMAL_LIBRARY)


### PR DESCRIPTION
Fixes #452 

Checks for both `tcmalloc` and `tcmalloc-minimal`

When installing only `tcmalloc-minimal` in Ubuntu, `libtcmalloc-minimal.so.4` is not symlinked with the unversioned `libtcmalloc-minimal.so`. (https://bugs.launchpad.net/ubuntu/+source/google-perftools/+bug/1219685)