### PR TITLE
ComplexDouble

### DIFF
--- a/csympy/lib/csympy.pxd
+++ b/csympy/lib/csympy.pxd
@@ -53,6 +53,7 @@ cdef extern from "symengine_rcp.h" namespace "SymEngine":
     RCP[const Abs] rcp_static_cast_Abs "SymEngine::rcp_static_cast<const SymEngine::Abs>"(RCP[const Basic] &b) nogil
     RCP[const Derivative] rcp_static_cast_Derivative "SymEngine::rcp_static_cast<const SymEngine::Derivative>"(RCP[const Basic] &b) nogil
     RCP[const Subs] rcp_static_cast_Subs "SymEngine::rcp_static_cast<const SymEngine::Subs>"(RCP[const Basic] &b) nogil
+    RCP[const ComplexDouble] rcp_static_cast_ComplexDouble "SymEngine::rcp_static_cast<const SymEngine::ComplexDouble>"(RCP[const Basic] &b) nogil
     Ptr[RCP[Basic]] outArg(RCP[const Basic] &arg) nogil
     Ptr[RCP[Integer]] outArg_Integer "SymEngine::outArg<SymEngine::RCP<const SymEngine::Integer>>"(RCP[const Integer] &arg) nogil
 
@@ -94,6 +95,7 @@ cdef extern from "basic.h" namespace "SymEngine":
     bool is_a_Subs "SymEngine::is_a<SymEngine::Subs>"(const Basic &b) nogil
     bool is_a_FunctionWrapper "SymEngine::is_a<SymEngine::FunctionWrapper>"(const Basic &b) nogil
     bool is_a_RealDouble "SymEngine::is_a<SymEngine::RealDouble>"(const Basic &b) nogil
+    bool is_a_ComplexDouble "SymEngine::is_a<SymEngine::ComplexDouble>"(const Basic &b) nogil
 
     RCP[const Basic] expand(RCP[const Basic] &o) nogil except +
 
@@ -128,6 +130,12 @@ cdef extern from "complex.h" namespace "SymEngine":
 cdef extern from "real_double.h" namespace "SymEngine":
     cdef cppclass RealDouble(Number):
         RealDouble(double x) nogil
+
+cdef extern from "complex_double.h" namespace "SymEngine":
+    cdef cppclass ComplexDouble(Number):
+        ComplexDouble(double complex x) nogil
+        RCP[const Number] real_part() nogil
+        RCP[const Number] imaginary_part() nogil
 
 cdef extern from "constants.h" namespace "SymEngine":
     cdef cppclass Constant(Basic):
@@ -172,6 +180,7 @@ cdef extern from "basic.h" namespace "SymEngine":
     RCP[const Basic] rcp(Derivative *p) nogil
     RCP[const Basic] rcp(FunctionWrapper *p) nogil
     RCP[const Basic] rcp(RealDouble *p) nogil
+    RCP[const Basic] rcp(ComplexDouble *p) nogil
 
 cdef extern from "functions.h" namespace "SymEngine":
     cdef RCP[const Basic] sin(RCP[const Basic] &arg) nogil except+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRC
     cwrapper.cpp
     printer.cpp
     real_double.cpp
+    complex_double.cpp
 )
 
 # Needed for "make install"
@@ -41,6 +42,7 @@ set(HEADERS
     symbol.h
     basic-inl.h  dict.h           matrix.h     ntheory.h    rational.h complex.h
     visitor.h    eval_double.h    diophantine.h cwrapper.h  printer.h  real_double.h
+    complex_double.h
 )
 
 # Configure SymEngine using our CMake options:

--- a/src/basic.h
+++ b/src/basic.h
@@ -62,7 +62,7 @@ class Symbol;
 */
 
 enum TypeID {
-    INTEGER, RATIONAL, COMPLEX, REAL_DOUBLE,
+    INTEGER, RATIONAL, COMPLEX, COMPLEX_DOUBLE, REAL_DOUBLE,
     // 'REAL_DOUBLE' returns the number of subclasses of Number.
     // All subclasses of Number must be added before it. Do not assign
     // non subclasses of Number before it.

--- a/src/complex_double.cpp
+++ b/src/complex_double.cpp
@@ -13,6 +13,14 @@ namespace SymEngine {
 ComplexDouble::ComplexDouble(std::complex<double> i) {
     this->i = i;
 }
+//! Get the real part of the complex number
+RCP<const Number> ComplexDouble::real_part() const {
+    return real_double(i.real());
+}
+//! Get the imaginary part of the complex number
+RCP<const Number> ComplexDouble::imaginary_part() const {
+    return real_double(i.imag());
+}
 std::size_t ComplexDouble::__hash__() const
 {
     std::size_t seed = COMPLEX_DOUBLE;

--- a/src/complex_double.cpp
+++ b/src/complex_double.cpp
@@ -1,0 +1,49 @@
+/**
+ *  \file ComplexDouble.h
+ *  Class for ComplexDouble built on top of Number class
+ *
+ **/
+#include <cmath>
+#include <complex>
+#include "basic.h"
+#include "complex_double.h"
+
+namespace SymEngine {
+
+ComplexDouble::ComplexDouble(std::complex<double> i) {
+    this->i = i;
+}
+std::size_t ComplexDouble::__hash__() const
+{
+    std::size_t seed = COMPLEX_DOUBLE;
+    hash_combine<double>(seed, i.real());
+    hash_combine<double>(seed, i.imag());
+    return seed;
+}
+
+bool ComplexDouble::__eq__(const Basic &o) const
+{
+    if (is_a<ComplexDouble>(o)) {
+        const ComplexDouble &s = static_cast<const ComplexDouble &>(o);
+        return this->i == s.i;
+    }
+    return false;
+}
+
+int ComplexDouble::compare(const Basic &o) const
+{
+    SYMENGINE_ASSERT(is_a<ComplexDouble>(o))
+    const ComplexDouble &s = static_cast<const ComplexDouble &>(o);
+    if (i == s.i) return 0;
+    if (i.real() == s.i.real()) {
+        return i.imag() < s.i.imag() ? -1 : 1;
+    }
+    return i.real() < s.i.real() ? -1 : 1;
+}
+
+RCP<const ComplexDouble> complex_double(std::complex<double> x)
+{
+    return rcp(new ComplexDouble(x));
+};
+
+} // SymEngine

--- a/src/complex_double.h
+++ b/src/complex_double.h
@@ -1,0 +1,459 @@
+/**
+ *  \file ComplexDouble.h
+ *  Class for ComplexDouble built on top of Number class
+ *
+ **/
+#ifndef SYMENGINE_COMPLEX_DOUBLE_H
+#define SYMENGINE_COMPLEX_DOUBLE_H
+
+#include <cmath>
+#include "basic.h"
+#include "number.h"
+#include "integer.h"
+#include "rational.h"
+#include "complex.h"
+#include "real_double.h"
+
+namespace SymEngine {
+//! Complex Double Class to hold std::complex<double> values
+class ComplexDouble : public Number {
+public:
+    std::complex<double> i;
+
+public:
+    IMPLEMENT_TYPEID(COMPLEX_DOUBLE)
+    //! Constructor of ComplexDouble class
+    ComplexDouble(std::complex<double> i);
+    //! \return size of the hash
+    virtual std::size_t __hash__() const;
+    /*! Equality comparator
+     * \param o - Object to be compared with
+     * \return whether the 2 objects are equal
+     * */
+    virtual bool __eq__(const Basic &o) const;
+    virtual int compare(const Basic &o) const;
+    //! \returns `false`
+    // False is returned because complex cannot be compared with zero
+    inline virtual bool is_positive() const {
+        return false;
+    }
+    //! \returns `false`
+    // False is returned because complex cannot be compared with zero
+    inline virtual bool is_negative() const {
+        return false;
+    }
+    //! \returns `false`
+    // False is returned because std::complex<double> is not exact
+    inline virtual bool is_exact() const { return false; }
+    //! Get `Evaluate` singleton to evaluate numerically
+    virtual Evaluate& get_eval() const;
+
+    //! \return `false`
+    // A std::complex<double> is not exactly equal to `0`
+    virtual bool is_zero() const { return false; }
+    //! \return `false`
+    // A std::complex<double> is not exactly equal to `1`
+    virtual bool is_one() const { return false; }
+    //! \return `false`
+    // A std::complex<double> is not exactly equal to `-1`
+    virtual bool is_minus_one() const { return false; }
+
+    /*! Add ComplexDoubles
+     * \param other of type Integer
+     * */
+    RCP<const Number> addcomp(const Integer &other) const {
+        return rcp(new ComplexDouble(i + other.i.get_d()));
+    }
+
+    /*! Add ComplexDoubles
+     * \param other of type Rational
+     * */
+    RCP<const Number> addcomp(const Rational &other) const {
+        return rcp(new ComplexDouble(i + other.i.get_d()));
+    }
+
+    /*! Add ComplexDoubles
+     * \param other of type Complex
+     * */
+    RCP<const Number> addcomp(const Complex &other) const {
+        return rcp(new ComplexDouble(i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+    }
+
+    /*! Add ComplexDoubles
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> addcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble(i + other.i));
+    }
+
+    /*! Add ComplexDoubles
+     * \param other of type ComplexDouble
+     * */
+    RCP<const Number> addcomp(const ComplexDouble &other) const {
+        return rcp(new ComplexDouble(i + other.i));
+    }
+
+    //! Converts the param `other` appropriately and then calls `addcomp`
+    virtual RCP<const Number> add(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return addcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return addcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return addcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return addcomp(static_cast<const RealDouble&>(other));
+        } else if (is_a<ComplexDouble>(other)) {
+            return addcomp(static_cast<const ComplexDouble&>(other));
+        } else {
+            return other.add(*this);
+        }
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type Integer
+     * */
+    RCP<const Number> subcomp(const Integer &other) const {
+        return rcp(new ComplexDouble(i - other.i.get_d()));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type Rational
+     * */
+    RCP<const Number> subcomp(const Rational &other) const {
+        return rcp(new ComplexDouble(i - other.i.get_d()));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type Complex
+     * */
+    RCP<const Number> subcomp(const Complex &other) const {
+        return rcp(new ComplexDouble(i - std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> subcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble(i - other.i));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type ComplexDouble
+     * */
+    RCP<const Number> subcomp(const ComplexDouble &other) const {
+        return rcp(new ComplexDouble(i - other.i));
+    }
+
+    //! Converts the param `other` appropriately and then calls `subcomp`
+    virtual RCP<const Number> sub(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return subcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return subcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return subcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return subcomp(static_cast<const RealDouble&>(other));
+        } else if (is_a<ComplexDouble>(other)) {
+            return subcomp(static_cast<const ComplexDouble&>(other));
+        } else {
+            return other.rsub(*this);
+        }
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type Integer
+     * */
+    RCP<const Number> rsubcomp(const Integer &other) const {
+        return rcp(new ComplexDouble(other.i.get_d() - i));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type Rational
+     * */
+    RCP<const Number> rsubcomp(const Rational &other) const {
+        return rcp(new ComplexDouble(other.i.get_d() - i));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type Complex
+     * */
+    RCP<const Number> rsubcomp(const Complex &other) const {
+        return rcp(new ComplexDouble(-i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+    }
+
+    /*! Subtract ComplexDoubles
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> rsubcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble(other.i - i));
+    }
+
+    //! Converts the param `other` appropriately and then calls `subcomp`
+    virtual RCP<const Number> rsub(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return rsubcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return rsubcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return rsubcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return rsubcomp(static_cast<const RealDouble&>(other));
+        } else {
+            throw std::runtime_error("Not implemented.");
+        }
+    }
+
+
+    /*! Multiply ComplexDoubles
+     * \param other of type Integer
+     * */
+    RCP<const Number> mulcomp(const Integer &other) const {
+        return rcp(new ComplexDouble(i * other.i.get_d()));
+    }
+
+    /*! Multiply ComplexDoubles
+     * \param other of type Rational
+     * */
+    RCP<const Number> mulcomp(const Rational &other) const {
+        return rcp(new ComplexDouble(i * other.i.get_d()));
+    }
+
+    /*! Multiply ComplexDoubles
+     * \param other of type Complex
+     * */
+    RCP<const Number> mulcomp(const Complex &other) const {
+        return rcp(new ComplexDouble(i * std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+    }
+
+    /*! Multiply ComplexDoubles
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> mulcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble(i * other.i));
+    }
+
+    /*! Multiply ComplexDoubles
+     * \param other of type ComplexDouble
+     * */
+    RCP<const Number> mulcomp(const ComplexDouble &other) const {
+        return rcp(new ComplexDouble(i * other.i));
+    }
+
+    //! Converts the param `other` appropriately and then calls `mulcomp`
+    virtual RCP<const Number> mul(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return mulcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return mulcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return mulcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return mulcomp(static_cast<const RealDouble&>(other));
+        } else if (is_a<ComplexDouble>(other)) {
+            return mulcomp(static_cast<const ComplexDouble&>(other));
+        } else {
+            return other.mul(*this);
+        }
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type Integer
+     * */
+    RCP<const Number> divcomp(const Integer &other) const {
+        return rcp(new ComplexDouble(i / other.i.get_d()));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type Rational
+     * */
+    RCP<const Number> divcomp(const Rational &other) const {
+        return rcp(new ComplexDouble(i / other.i.get_d()));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type Complex
+     * */
+    RCP<const Number> divcomp(const Complex &other) const {
+        return rcp(new ComplexDouble(i / std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> divcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble(i / other.i));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type ComplexDouble
+     * */
+    RCP<const Number> divcomp(const ComplexDouble &other) const {
+        return rcp(new ComplexDouble(i / other.i));
+    }
+
+    //! Converts the param `other` appropriately and then calls `divcomp`
+    virtual RCP<const Number> div(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return divcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return divcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return divcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return divcomp(static_cast<const RealDouble&>(other));
+        } else if (is_a<ComplexDouble>(other)) {
+            return divcomp(static_cast<const ComplexDouble&>(other));
+        } else {
+            return other.rdiv(*this);
+        }
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type Integer
+     * */
+    RCP<const Number> rdivcomp(const Integer &other) const {
+        return rcp(new ComplexDouble(other.i.get_d() / i));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type Rational
+     * */
+    RCP<const Number> rdivcomp(const Rational &other) const {
+        return rcp(new ComplexDouble(other.i.get_d() / i));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type Complex
+     * */
+    RCP<const Number> rdivcomp(const Complex &other) const {
+        return rcp(new ComplexDouble(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()) / i));
+    }
+
+    /*! Divide ComplexDoubles
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> rdivcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble(other.i / i));
+    }
+
+    //! Converts the param `other` appropriately and then calls `divcomp`
+    virtual RCP<const Number> rdiv(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return rdivcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return rdivcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return rdivcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return rdivcomp(static_cast<const RealDouble&>(other));
+        } else {
+            throw std::runtime_error("Not implemented.");
+        }
+    }
+
+    /*! Raise ComplexDouble to power `other`
+     * \param other of type Integer
+     * */
+    RCP<const Number> powcomp(const Integer &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i.get_d())));
+    }
+
+    /*! Raise ComplexDouble to power `other`
+     * \param other of type Rational
+     * */
+    RCP<const Number> powcomp(const Rational &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i.get_d())));
+    }
+
+    /*! Raise ComplexDouble to power `other`
+     * \param other of type Complex
+     * */
+    RCP<const Number> powcomp(const Complex &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()))));
+    }
+
+    /*! Raise ComplexDouble to power `other`
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> powcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i)));
+    }
+
+
+    /*! Raise ComplexDouble to power `other`
+     * \param other of type ComplexDouble
+     * */
+    RCP<const Number> powcomp(const ComplexDouble &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i)));
+    }
+
+    //! Converts the param `other` appropriately and then calls `powcomp`
+    virtual RCP<const Number> pow(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return powcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return powcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return powcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return powcomp(static_cast<const RealDouble&>(other));
+        } else if (is_a<ComplexDouble>(other)) {
+            return powcomp(static_cast<const ComplexDouble&>(other));
+        } else {
+            return other.rpow(*this);
+        }
+    }
+
+    /*! Raise `other` to power ComplexDouble
+     * \param other of type Integer
+     * */
+    RCP<const Number> rpowcomp(const Integer &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(other.i.get_d(), i)));
+    }
+
+    /*! Raise `other` to power ComplexDouble
+     * \param other of type Rational
+     * */
+    RCP<const Number> rpowcomp(const Rational &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(other.i.get_d(), i)));
+    }
+
+    /*! Raise `other` to power ComplexDouble
+     * \param other of type Complex
+     * */
+    RCP<const Number> rpowcomp(const Complex &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()), i)));
+    }
+
+    /*! Raise `other` to power ComplexDouble
+     * \param other of type RealDouble
+     * */
+    RCP<const Number> rpowcomp(const RealDouble &other) const {
+        return rcp(new ComplexDouble((std::complex<double>)std::pow(other.i, i)));
+    }
+
+    //! Converts the param `other` appropriately and then calls `powcomp`
+    virtual RCP<const Number> rpow(const Number &other) const {
+        if (is_a<Rational>(other)) {
+            return rpowcomp(static_cast<const Rational&>(other));
+        } else if (is_a<Integer>(other)) {
+            return rpowcomp(static_cast<const Integer&>(other));
+        } else if (is_a<Complex>(other)) {
+            return rpowcomp(static_cast<const Complex&>(other));
+        } else if (is_a<RealDouble>(other)) {
+            return rpowcomp(static_cast<const RealDouble&>(other));
+        } else {
+            throw std::runtime_error("Not implemented.");
+        }
+    }
+
+    virtual void accept(Visitor &v) const;
+};
+
+RCP<const ComplexDouble> complex_double(std::complex<double> x);
+
+} // SymEngine
+
+#endif

--- a/src/complex_double.h
+++ b/src/complex_double.h
@@ -32,6 +32,10 @@ public:
      * */
     virtual bool __eq__(const Basic &o) const;
     virtual int compare(const Basic &o) const;
+    //! Get the real part of the complex number
+    RCP<const Number> real_part() const;
+    //! Get the imaginary part of the complex number
+    RCP<const Number> imaginary_part() const;
     //! \returns `false`
     // False is returned because complex cannot be compared with zero
     inline virtual bool is_positive() const {

--- a/src/eval_arb.cpp
+++ b/src/eval_arb.cpp
@@ -128,6 +128,10 @@ public:
         throw std::runtime_error("Not implemented.");
     }
 
+    virtual void visit(const ComplexDouble &x) {
+        throw std::runtime_error("Not implemented.");
+    }
+
     virtual void visit(const Log &x) {
         apply(result_, *(x.get_arg()));
         arb_log(result_, result_, prec_);

--- a/src/eval_double.cpp
+++ b/src/eval_double.cpp
@@ -214,7 +214,7 @@ public:
     // Classes not implemented are
     // Subs, UpperGamma, LowerGamma, Dirichlet_eta, Zeta
     // LeviCivita, KroneckerDelta, FunctionSymbol, LambertW
-    // Derivative, Complex
+    // Derivative, Complex, ComplexDouble
 
     using EvalDoubleVisitor::bvisit;
 
@@ -243,6 +243,10 @@ public:
 
     void bvisit(const Complex &x) {
         result_ = std::complex<double>(x.real_.get_d(), x.imaginary_.get_d());
+    };
+
+    void bvisit(const ComplexDouble &x) {
+        result_ = x.i;
     };
 };
 

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -68,6 +68,18 @@ void StrPrinter::bvisit(const RealDouble &x) {
     str_ = s.str();
 }
 
+void StrPrinter::bvisit(const ComplexDouble &x) {
+    std::ostringstream s;
+    s.precision(std::numeric_limits< double >::digits10);
+    s << std::scientific << x.i.real();
+    if (x.i.imag() < 0) {
+        s << " - (" << -x.i.imag() << ")*I";
+    } else {
+        s << " + (" << x.i.imag() << ")*I";
+    }
+    str_ = s.str();
+}
+
 void StrPrinter::bvisit(const Add &x) {
     std::ostringstream o;
     bool first = true;

--- a/src/printer.h
+++ b/src/printer.h
@@ -55,6 +55,10 @@ public:
         precedence = PrecedenceEnum::Add;
     }
 
+    void bvisit(const ComplexDouble &x) {
+        precedence = PrecedenceEnum::Add;
+    }
+
     void bvisit(const Basic &x) {
         precedence = PrecedenceEnum::Atom;
     }
@@ -86,6 +90,7 @@ public:
     void bvisit(const Derivative &x);
     void bvisit(const Subs &x);
     void bvisit(const RealDouble &x);
+    void bvisit(const ComplexDouble &x);
 
     std::string parenthesizeLT(const RCP<const Basic> &x, PrecedenceEnum precedenceEnum);
     std::string parenthesizeLE(const RCP<const Basic> &x, PrecedenceEnum precedenceEnum);

--- a/src/real_double.cpp
+++ b/src/real_double.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include "basic.h"
 #include "real_double.h"
+#include "complex_double.h"
 
 namespace SymEngine {
 
@@ -16,8 +17,6 @@ RealDouble::RealDouble(double i) {
 std::size_t RealDouble::__hash__() const
 {
     std::hash<double> hash_fn;
-    // only the least significant bits that fit into "signed long int" are
-    // hashed:
     return hash_fn(i);
 }
 
@@ -40,104 +39,126 @@ int RealDouble::compare(const Basic &o) const
 
 RCP<const RealDouble> real_double(double x) { return rcp(new RealDouble(x)); };
 
+RCP<const Number> number(std::complex<double> x) { return complex_double(x); };
+RCP<const Number> number(double x) { return real_double(x); };
+
 //! Evaluate functions with double precision
+template<class T>
 class EvaluateDouble : public Evaluate {
     virtual RCP<const Basic> sin(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::sin(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::sin(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> cos(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::cos(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::cos(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> tan(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::tan(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::tan(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> cot(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(1/std::tan(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(1.0/std::tan(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> sec(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(1/std::sin(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(1.0/std::sin(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> csc(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(1/std::cos(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(1.0/std::cos(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> asin(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::asin(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::asin(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acos(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::acos(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::acos(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> atan(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::atan(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::atan(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acot(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::atan(1/static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::atan(1.0/static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> asec(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::acos(1/static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::acos(1.0/static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acsc(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::asin(1/static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::asin(1.0/static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> sinh(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::sinh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::sinh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> cosh(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::cosh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::cosh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> tanh(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::tanh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::tanh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> coth(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(1/std::tanh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(1.0/std::tanh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> asinh(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::asinh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::asinh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acosh(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::acosh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::acosh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> atanh(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::atanh(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::atanh(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> acoth(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::atanh(1/static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::atanh(1.0/static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> log(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::log(static_cast<const RealDouble &>(x).i));
-    }
-    virtual RCP<const Basic> gamma(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::tgamma(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::log(static_cast<const T &>(x).i));
     }
     virtual RCP<const Basic> abs(const Basic &x) const {
-        SYMENGINE_ASSERT(is_a<RealDouble>(x))
-        return real_double(std::abs(static_cast<const RealDouble &>(x).i));
+        SYMENGINE_ASSERT(is_a<T>(x))
+        return number(std::abs(static_cast<const T &>(x).i));
     }
 };
 
-Evaluate& RealDouble::get_eval() const {
-    static EvaluateDouble evaluate_double;
-    return evaluate_double;
+class EvaluateRealDouble : public EvaluateDouble<RealDouble> {
+    virtual RCP<const Basic> gamma(const Basic &x) const {
+        SYMENGINE_ASSERT(is_a<RealDouble>(x))
+        return number(std::tgamma(static_cast<const RealDouble &>(x).i));
+    }
+};
+
+class EvaluateComplexDouble : public EvaluateDouble<RealDouble> {
+    virtual RCP<const Basic> gamma(const Basic &x) const {
+        SYMENGINE_ASSERT(is_a<RealDouble>(x))
+        throw std::runtime_error("Not Implemented.");
+    }
+};
+
+Evaluate& RealDouble::get_eval() const
+{
+    static EvaluateRealDouble evaluate_real_double;
+    return evaluate_real_double;
 }
+
+Evaluate& ComplexDouble::get_eval() const
+{
+    static EvaluateComplexDouble evaluate_complex_double;
+    return evaluate_complex_double;
+}
+
 } // SymEngine

--- a/src/real_double.h
+++ b/src/real_double.h
@@ -7,6 +7,7 @@
 #define SYMENGINE_REAL_DOUBLE_H
 
 #include <cmath>
+#include <complex>
 #include "basic.h"
 #include "number.h"
 #include "integer.h"
@@ -14,6 +15,10 @@
 #include "complex.h"
 
 namespace SymEngine {
+
+RCP<const Number> number(std::complex<double> x);
+RCP<const Number> number(double x);
+
 //! RealDouble Class to hold double values
 class RealDouble : public Number {
 public:
@@ -23,8 +28,6 @@ public:
     IMPLEMENT_TYPEID(REAL_DOUBLE)
     //! Constructor of RealDouble class
     RealDouble(double i);
-    //! \return true if canonical
-    bool is_canonical(const double i) { return false; }
     //! \return size of the hash
     virtual std::size_t __hash__() const;
     /*! Equality comparator
@@ -74,7 +77,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> addreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Add RealDoubles
@@ -117,7 +120,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> subreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(i - std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Subtract RealDoubles
@@ -160,7 +163,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> rsubreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(-i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     //! Converts the param `other` appropriately and then calls `subreal`
@@ -195,7 +198,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> mulreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(i * std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Multiply RealDoubles
@@ -238,7 +241,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> divreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(i / std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Divide RealDoubles
@@ -281,7 +284,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> rdivreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()) / i);
     }
 
     //! Converts the param `other` appropriately and then calls `divreal`
@@ -309,7 +312,7 @@ public:
      * */
     RCP<const Number> powreal(const Rational &other) const {
         if (i < 0 && mpz_even_p(other.i.get_den().get_mpz_t())) {
-            throw std::runtime_error("Not implemented.");
+            return number(std::pow(std::complex<double>(i), other.i.get_d()));
         }
         return rcp(new RealDouble(std::pow(i, other.i.get_d())));
     }
@@ -318,7 +321,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> powreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(std::pow(i, std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
     }
 
     /*! Raise RealDouble to power `other`
@@ -326,7 +329,7 @@ public:
      * */
     RCP<const Number> powreal(const RealDouble &other) const {
         if (i < 0) {
-            throw std::runtime_error("Not implemented.");
+            return number(std::pow(std::complex<double>(i), other.i));
         }
         return rcp(new RealDouble(std::pow(i, other.i)));
     }
@@ -351,7 +354,7 @@ public:
      * */
     RCP<const Number> rpowreal(const Integer &other) const {
         if (other.is_negative()) {
-            throw std::runtime_error("Not implemented.");
+            return number(std::pow(other.i.get_d(), std::complex<double>(i)));
         }
         return rcp(new RealDouble(std::pow(other.i.get_d(), i)));
     }
@@ -361,7 +364,7 @@ public:
      * */
     RCP<const Number> rpowreal(const Rational &other) const {
         if (other.is_negative()) {
-            throw std::runtime_error("Not implemented.");
+            return number(std::pow(std::complex<double>(i), other.i.get_d()));
         }
         return rcp(new RealDouble(std::pow(other.i.get_d(), i)));
     }
@@ -370,7 +373,7 @@ public:
      * \param other of type Complex
      * */
     RCP<const Number> rpowreal(const Complex &other) const {
-        throw std::runtime_error("Not implemented.");
+        return number(std::pow(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()), i));
     }
 
     //! Converts the param `other` appropriately and then calls `powreal`

--- a/src/real_double.h
+++ b/src/real_double.h
@@ -311,7 +311,7 @@ public:
      * \param other of type Rational
      * */
     RCP<const Number> powreal(const Rational &other) const {
-        if (i < 0 && mpz_even_p(other.i.get_den().get_mpz_t())) {
+        if (i < 0) {
             return number(std::pow(std::complex<double>(i), other.i.get_d()));
         }
         return rcp(new RealDouble(std::pow(i, other.i.get_d())));

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -294,6 +294,13 @@ void test_sub()
     r2 = sub(sub(sub(r1, r2), integer(3)), real_double(0.2));
     assert(is_a<RealDouble>(*r2));
     assert(std::abs(rcp_static_cast<const RealDouble>(r2)->i + 3.6) < 1e-12);
+
+    r1 = real_double(0.1);
+    r2 = Complex::from_two_nums(*Rational::from_mpq(mpq_class(1, 2)), *Rational::from_mpq(mpq_class(7, 5)));
+    r2 = sub(sub(sub(r1, r2), integer(1)), real_double(0.4));
+    assert(is_a<ComplexDouble>(*r2));
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.real() + 1.8) < 1e-12);
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.imag() + 1.4) < 1e-12);
 }
 
 void test_div()
@@ -395,6 +402,13 @@ void test_div()
     r2 = div(div(div(r1, r2), integer(3)), real_double(0.2));
     assert(is_a<RealDouble>(*r2));
     assert(std::abs(rcp_static_cast<const RealDouble>(r2)->i - 0.333333333333) < 1e-12);
+
+    r1 = real_double(0.1);
+    r2 = Complex::from_two_nums(*Rational::from_mpq(mpq_class(1, 2)), *Rational::from_mpq(mpq_class(7, 5)));
+    r2 = div(div(div(r1, r2), integer(2)), real_double(0.4));
+    assert(is_a<ComplexDouble>(*r2));
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.real() - 0.0282805429864253) < 1e-12);
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.imag() + 0.0791855203619909) < 1e-12);
 }
 
 void test_pow()
@@ -613,6 +627,13 @@ void test_pow()
     assert(std::abs(rcp_static_cast<const RealDouble>(r2)->i - 0.316227766016) < 1e-12);
     r2 = pow(pow(r2, integer(3)), real_double(0.2));
     assert(std::abs(rcp_static_cast<const RealDouble>(r2)->i - 0.501187233627) < 1e-12);
+
+    r1 = real_double(-0.01);
+    r2 = pow(r1, Rational::from_mpq(mpq_class(1, 2)));
+    r2 = pow(integer(2), r2);
+    assert(is_a<ComplexDouble>(*r2));
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.real() - 0.997598696589298) < 1e-12);
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.imag() - 0.069259227279362) < 1e-12);
 }
 
 void test_log()

--- a/src/tests/basic/test_arit.cpp
+++ b/src/tests/basic/test_arit.cpp
@@ -12,6 +12,7 @@
 #include "complex.h"
 #include "constants.h"
 #include "real_double.h"
+#include "complex_double.h"
 
 using SymEngine::Basic;
 using SymEngine::Add;
@@ -46,7 +47,9 @@ using SymEngine::rcp_dynamic_cast;
 using SymEngine::rcp_static_cast;
 using SymEngine::print_stack_on_segfault;
 using SymEngine::RealDouble;
+using SymEngine::ComplexDouble;
 using SymEngine::real_double;
+using SymEngine::complex_double;
 using SymEngine::is_a;
 
 void test_add()
@@ -103,6 +106,13 @@ void test_add()
     r3 = add(add(add(r1, r2), integer(1)), real_double(0.2));
     assert(is_a<RealDouble>(*r3));
     assert(std::abs(rcp_static_cast<const RealDouble>(r3)->i - 1.8) < 1e-12);
+
+    r1 = complex_double(std::complex<double>(0.1, 0.2));
+    r2 = Complex::from_two_nums(*Rational::from_mpq(mpq_class(1, 2)), *Rational::from_mpq(mpq_class(7, 5)));
+    r3 = add(add(add(r1, r2), integer(1)), real_double(0.4));
+    assert(is_a<ComplexDouble>(*r3));
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r3)->i.real() - 2.0) < 1e-12);
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r3)->i.imag() - 1.6) < 1e-12);
 }
 
 void test_mul()
@@ -207,6 +217,13 @@ void test_mul()
     r2 = mul(mul(mul(r1, r2), integer(3)), real_double(0.2));
     assert(is_a<RealDouble>(*r2));
     assert(std::abs(rcp_static_cast<const RealDouble>(r2)->i - 0.03) < 1e-12);
+
+    r1 = complex_double(std::complex<double>(0.1, 0.2));
+    r2 = Complex::from_two_nums(*Rational::from_mpq(mpq_class(1, 2)), *Rational::from_mpq(mpq_class(7, 5)));
+    r2 = mul(mul(mul(r1, r2), integer(5)), real_double(0.7));
+    assert(is_a<ComplexDouble>(*r2));
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.real() + 0.805) < 1e-12);
+    assert(std::abs(rcp_static_cast<const ComplexDouble>(r2)->i.imag() - 0.84) < 1e-12);
 }
 
 void test_sub()

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -11,6 +11,7 @@
 #include "functions.h"
 #include "constants.h"
 #include "visitor.h"
+#include "complex_double.h"
 
 #define ACCEPT(CLASS) void CLASS::accept(Visitor &v) const { v.visit(*this); }
 
@@ -60,6 +61,7 @@ ACCEPT(Constant)
 ACCEPT(Abs)
 ACCEPT(Subs)
 ACCEPT(RealDouble)
+ACCEPT(ComplexDouble)
 
 void preorder_traversal(const Basic &b, Visitor &v)
 {

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -17,6 +17,7 @@
 #include "complex.h"
 #include "constants.h"
 #include "real_double.h"
+#include "complex_double.h"
 
 namespace SymEngine {
 
@@ -66,6 +67,7 @@ public:
     virtual void visit(const Abs &) = 0;
     virtual void visit(const Subs &) = 0;
     virtual void visit(const RealDouble &) = 0;
+    virtual void visit(const ComplexDouble &) = 0;
 };
 
 void preorder_traversal(const Basic &b, Visitor &v);
@@ -124,6 +126,7 @@ public:
     virtual void visit(const Abs &x) { p_->bvisit(x); };
     virtual void visit(const Subs &x) { p_->bvisit(x); };
     virtual void visit(const RealDouble &x) { p_->bvisit(x); };
+    virtual void visit(const ComplexDouble &x) { p_->bvisit(x); };
 };
 
 template<class T>


### PR DESCRIPTION
This class would keep a `std::complex<double>`
I implemented some not implemented methods in `RealDouble` as well.
For eg. now `1+2*I + 0.2` gives `1.2 + 2.0*I`.
This way, the fact that the imaginary part is exact is lost though.