### PR TITLE
Use initializer list for Integer::Integer()

### DIFF
--- a/src/integer.cpp
+++ b/src/integer.cpp
@@ -8,11 +8,6 @@ Integer::Integer(int i)
     this->i = i;
 }
 
-Integer::Integer(mpz_class i)
-{
-    this->i = i;
-}
-
 std::size_t Integer::__hash__() const
 {
     std::hash<long long int> hash_fn;

--- a/src/integer.h
+++ b/src/integer.h
@@ -175,6 +175,8 @@ int perfect_power(const Integer &n);
 //! Integer Absolute value
 RCP<const Integer> iabs(const Integer &n);
 
+inline Integer::Integer(mpz_class i) : i{i} {}
+
 } // SymEngine
 
 #endif


### PR DESCRIPTION
This provides a nice few percent speedup in e.g. the expand2 benchmark.