### PR TITLE
Implement make_rcp, get_rcp, get_rcp_cast and use it

### DIFF
--- a/cmake/checkgmpxx.cpp
+++ b/cmake/checkgmpxx.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <iostream>
 #include <gmpxx.h>
 

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -144,7 +144,7 @@ RCP<const Basic> Add::from_dict(const RCP<const Number> &coef, umap_basic_num &&
             } else {
                 insert(m, p->first, one);
             }
-            return rcp(new Mul(p->second, std::move(m)));
+            return make_rcp<const Mul>(p->second, std::move(m));
         }
         map_basic_basic m;
         if (is_a_Number(*p->second)) {
@@ -177,14 +177,14 @@ RCP<const Basic> Add::from_dict(const RCP<const Number> &coef, umap_basic_num &&
             } else {
                 insert(m, p->first, one);
             }
-            return rcp(new Mul(p->second, std::move(m)));
+            return make_rcp<const Mul>(p->second, std::move(m));
         } else {
             insert(m, p->first, one);
             insert(m, p->second, one);
-            return rcp(new Mul(one, std::move(m)));
+            return make_rcp<const Mul>(one, std::move(m));
         }
     } else {
-        return rcp(new Add(coef, std::move(d)));
+        return make_rcp<const Add>(coef, std::move(d));
     }
 }
 

--- a/symengine/add.cpp
+++ b/symengine/add.cpp
@@ -335,7 +335,7 @@ void Add::as_two_terms(const Ptr<RCP<const Basic>> &a,
 
 RCP<const Basic> Add::subs(const map_basic_basic &subs_dict) const
 {
-    RCP<const Add> self = rcp_const_cast<Add>(rcp(this));
+    RCP<const Add> self = get_rcp_cast<const Add>();
     auto it = subs_dict.find(self);
     if (it != subs_dict.end())
         return it->second;

--- a/symengine/basic-inl.h
+++ b/symengine/basic-inl.h
@@ -38,6 +38,18 @@ inline bool is_a_sub(const Basic &b)
     return dynamic_cast<const T *>(&b) != nullptr;
 }
 
+template<typename T, typename ...Args>
+inline RCP<T> make_rcp( Args&& ...args )
+{
+#if defined(WITH_SYMENGINE_RCP)
+    return rcp( new T( std::forward<Args>(args)... ) );
+#else
+    RCP<T> p = rcp( new T( std::forward<Args>(args)... ) );
+    p->weak_self_ptr_ = p.create_weak();
+    return p;
+#endif
+}
+
 } // SymEngine
 
 // global namespace functions

--- a/symengine/basic.cpp
+++ b/symengine/basic.cpp
@@ -54,11 +54,7 @@ RCP<const Basic> Basic::subs(const map_basic_basic &subs_dict) const
 
 RCP<const Basic> Basic::diff(const RCP<const Symbol> &x) const
 {
-    // A brace enclosed initializer list cannot be forwarded. There are some
-    // complicated workarounds, but for now we just first initialize the
-    // `vec_basic`, then pass it into the make_rcp.
-    const vec_basic &v = {x};
-    return make_rcp<const Derivative>(get_rcp(), v);
+    return Derivative::create(get_rcp(), {x});
 }
 
 } // SymEngine

--- a/symengine/basic.cpp
+++ b/symengine/basic.cpp
@@ -54,7 +54,11 @@ RCP<const Basic> Basic::subs(const map_basic_basic &subs_dict) const
 
 RCP<const Basic> Basic::diff(const RCP<const Symbol> &x) const
 {
-    return rcp(new Derivative(get_rcp(), {x}));
+    // A brace enclosed initializer list cannot be forwarded. There are some
+    // complicated workarounds, but for now we just first initialize the
+    // `vec_basic`, then pass it into the make_rcp.
+    const vec_basic &v = {x};
+    return make_rcp<const Derivative>(get_rcp(), v);
 }
 
 } // SymEngine

--- a/symengine/basic.cpp
+++ b/symengine/basic.cpp
@@ -44,7 +44,7 @@ RCP<const Basic> expand(const RCP<const Basic> &self)
 
 RCP<const Basic> Basic::subs(const map_basic_basic &subs_dict) const
 {
-    RCP<const Basic> self = rcp_const_cast<Basic>(rcp(this));
+    RCP<const Basic> self = get_rcp();
     auto it = subs_dict.find(self);
     if (it == subs_dict.end())
         return self;
@@ -54,7 +54,7 @@ RCP<const Basic> Basic::subs(const map_basic_basic &subs_dict) const
 
 RCP<const Basic> Basic::diff(const RCP<const Symbol> &x) const
 {
-    return rcp(new Derivative(rcp(this), {x}));
+    return rcp(new Derivative(get_rcp(), {x}));
 }
 
 } // SymEngine

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -135,11 +135,13 @@ public:
     //! Assignment operator in continuation with above
     Basic& operator=(Basic&&) = delete;
 
-#if !defined(WITH_SYMENGINE_RCP)
     RCP<const Basic> get_rcp() const {
+#if defined(WITH_SYMENGINE_RCP)
+        return rcp(this);
+#else
         return weak_self_ptr_.create_strong();
-    }
 #endif
+    }
 
     /*!  Implements the hash of the given SymEngine class.
          Use `std::hash` to get the hash. Example:

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -136,8 +136,13 @@ public:
     Basic& operator=(Basic&&) = delete;
 
     RCP<const Basic> get_rcp() const {
+        return get_rcp_cast<const Basic>();
+    }
+
+    template <class T>
+    RCP<T> get_rcp_cast() const {
 #if defined(WITH_SYMENGINE_RCP)
-        return rcp(this);
+        return rcp(static_cast<T*>(this));
 #else
         return weak_self_ptr_.create_strong();
 #endif

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -144,7 +144,7 @@ public:
 #if defined(WITH_SYMENGINE_RCP)
         return rcp(static_cast<T*>(this));
 #else
-        return weak_self_ptr_.create_strong();
+        return rcp_static_cast<T>(weak_self_ptr_.create_strong());
 #endif
     }
 

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -109,6 +109,9 @@ public:
 #else
     mutable unsigned int refcount_; // reference counter
 #endif // WITH_SYMENGINE_THREAD_SAFE
+#else
+public:
+    mutable RCP<const Basic> weak_self_ptr_;
 #endif // WITH_SYMENGINE_RCP
 public:
     virtual TypeID get_type_code() const = 0;
@@ -131,6 +134,12 @@ public:
     Basic(Basic&&) = delete;
     //! Assignment operator in continuation with above
     Basic& operator=(Basic&&) = delete;
+
+#if !defined(WITH_SYMENGINE_RCP)
+    RCP<const Basic> get_rcp() const {
+        return weak_self_ptr_.create_strong();
+    }
+#endif
 
     /*!  Implements the hash of the given SymEngine class.
          Use `std::hash` to get the hash. Example:

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -255,6 +255,9 @@ bool is_a_sub(const Basic &b);
 //! Expands `self`
 RCP<const Basic> expand(const RCP<const Basic> &self);
 
+template<typename T, typename ...Args>
+inline RCP<T> make_rcp( Args&& ...args );
+
 } // SymEngine
 
 /*! This `<<` overloaded function simply calls `p.__str__`, so it allows any Basic

--- a/symengine/complex.cpp
+++ b/symengine/complex.cpp
@@ -67,7 +67,7 @@ RCP<const Number> Complex::from_mpq(const mpq_class re, const mpq_class im)
     if (im.get_num() == 0) {
         return Rational::from_mpq(re);
     } else {
-        return rcp(new Complex(re, im));
+        return make_rcp<const Complex>(re, im);
     }
 
 }

--- a/symengine/complex_double.cpp
+++ b/symengine/complex_double.cpp
@@ -51,7 +51,7 @@ int ComplexDouble::compare(const Basic &o) const
 
 RCP<const ComplexDouble> complex_double(std::complex<double> x)
 {
-    return rcp(new ComplexDouble(x));
+    return make_rcp<const ComplexDouble>(x);
 };
 
 } // SymEngine

--- a/symengine/complex_double.h
+++ b/symengine/complex_double.h
@@ -66,35 +66,35 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> addcomp(const Integer &other) const {
-        return rcp(new ComplexDouble(i + other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i + other.i.get_d());
     }
 
     /*! Add ComplexDoubles
      * \param other of type Rational
      * */
     RCP<const Number> addcomp(const Rational &other) const {
-        return rcp(new ComplexDouble(i + other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i + other.i.get_d());
     }
 
     /*! Add ComplexDoubles
      * \param other of type Complex
      * */
     RCP<const Number> addcomp(const Complex &other) const {
-        return rcp(new ComplexDouble(i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+        return make_rcp<const ComplexDouble>(i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Add ComplexDoubles
      * \param other of type RealDouble
      * */
     RCP<const Number> addcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble(i + other.i));
+        return make_rcp<const ComplexDouble>(i + other.i);
     }
 
     /*! Add ComplexDoubles
      * \param other of type ComplexDouble
      * */
     RCP<const Number> addcomp(const ComplexDouble &other) const {
-        return rcp(new ComplexDouble(i + other.i));
+        return make_rcp<const ComplexDouble>(i + other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `addcomp`
@@ -118,35 +118,35 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> subcomp(const Integer &other) const {
-        return rcp(new ComplexDouble(i - other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i - other.i.get_d());
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type Rational
      * */
     RCP<const Number> subcomp(const Rational &other) const {
-        return rcp(new ComplexDouble(i - other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i - other.i.get_d());
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type Complex
      * */
     RCP<const Number> subcomp(const Complex &other) const {
-        return rcp(new ComplexDouble(i - std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+        return make_rcp<const ComplexDouble>(i - std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type RealDouble
      * */
     RCP<const Number> subcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble(i - other.i));
+        return make_rcp<const ComplexDouble>(i - other.i);
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type ComplexDouble
      * */
     RCP<const Number> subcomp(const ComplexDouble &other) const {
-        return rcp(new ComplexDouble(i - other.i));
+        return make_rcp<const ComplexDouble>(i - other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `subcomp`
@@ -170,28 +170,28 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> rsubcomp(const Integer &other) const {
-        return rcp(new ComplexDouble(other.i.get_d() - i));
+        return make_rcp<const ComplexDouble>(other.i.get_d() - i);
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type Rational
      * */
     RCP<const Number> rsubcomp(const Rational &other) const {
-        return rcp(new ComplexDouble(other.i.get_d() - i));
+        return make_rcp<const ComplexDouble>(other.i.get_d() - i);
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type Complex
      * */
     RCP<const Number> rsubcomp(const Complex &other) const {
-        return rcp(new ComplexDouble(-i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+        return make_rcp<const ComplexDouble>(-i + std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Subtract ComplexDoubles
      * \param other of type RealDouble
      * */
     RCP<const Number> rsubcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble(other.i - i));
+        return make_rcp<const ComplexDouble>(other.i - i);
     }
 
     //! Converts the param `other` appropriately and then calls `subcomp`
@@ -214,35 +214,35 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> mulcomp(const Integer &other) const {
-        return rcp(new ComplexDouble(i * other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i * other.i.get_d());
     }
 
     /*! Multiply ComplexDoubles
      * \param other of type Rational
      * */
     RCP<const Number> mulcomp(const Rational &other) const {
-        return rcp(new ComplexDouble(i * other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i * other.i.get_d());
     }
 
     /*! Multiply ComplexDoubles
      * \param other of type Complex
      * */
     RCP<const Number> mulcomp(const Complex &other) const {
-        return rcp(new ComplexDouble(i * std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+        return make_rcp<const ComplexDouble>(i * std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Multiply ComplexDoubles
      * \param other of type RealDouble
      * */
     RCP<const Number> mulcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble(i * other.i));
+        return make_rcp<const ComplexDouble>(i * other.i);
     }
 
     /*! Multiply ComplexDoubles
      * \param other of type ComplexDouble
      * */
     RCP<const Number> mulcomp(const ComplexDouble &other) const {
-        return rcp(new ComplexDouble(i * other.i));
+        return make_rcp<const ComplexDouble>(i * other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `mulcomp`
@@ -266,35 +266,35 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> divcomp(const Integer &other) const {
-        return rcp(new ComplexDouble(i / other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i / other.i.get_d());
     }
 
     /*! Divide ComplexDoubles
      * \param other of type Rational
      * */
     RCP<const Number> divcomp(const Rational &other) const {
-        return rcp(new ComplexDouble(i / other.i.get_d()));
+        return make_rcp<const ComplexDouble>(i / other.i.get_d());
     }
 
     /*! Divide ComplexDoubles
      * \param other of type Complex
      * */
     RCP<const Number> divcomp(const Complex &other) const {
-        return rcp(new ComplexDouble(i / std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
+        return make_rcp<const ComplexDouble>(i / std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()));
     }
 
     /*! Divide ComplexDoubles
      * \param other of type RealDouble
      * */
     RCP<const Number> divcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble(i / other.i));
+        return make_rcp<const ComplexDouble>(i / other.i);
     }
 
     /*! Divide ComplexDoubles
      * \param other of type ComplexDouble
      * */
     RCP<const Number> divcomp(const ComplexDouble &other) const {
-        return rcp(new ComplexDouble(i / other.i));
+        return make_rcp<const ComplexDouble>(i / other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `divcomp`
@@ -318,28 +318,28 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> rdivcomp(const Integer &other) const {
-        return rcp(new ComplexDouble(other.i.get_d() / i));
+        return make_rcp<const ComplexDouble>(other.i.get_d() / i);
     }
 
     /*! Divide ComplexDoubles
      * \param other of type Rational
      * */
     RCP<const Number> rdivcomp(const Rational &other) const {
-        return rcp(new ComplexDouble(other.i.get_d() / i));
+        return make_rcp<const ComplexDouble>(other.i.get_d() / i);
     }
 
     /*! Divide ComplexDoubles
      * \param other of type Complex
      * */
     RCP<const Number> rdivcomp(const Complex &other) const {
-        return rcp(new ComplexDouble(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()) / i));
+        return make_rcp<const ComplexDouble>(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()) / i);
     }
 
     /*! Divide ComplexDoubles
      * \param other of type RealDouble
      * */
     RCP<const Number> rdivcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble(other.i / i));
+        return make_rcp<const ComplexDouble>(other.i / i);
     }
 
     //! Converts the param `other` appropriately and then calls `divcomp`
@@ -361,28 +361,28 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> powcomp(const Integer &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i.get_d())));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(i, other.i.get_d()));
     }
 
     /*! Raise ComplexDouble to power `other`
      * \param other of type Rational
      * */
     RCP<const Number> powcomp(const Rational &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i.get_d())));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(i, other.i.get_d()));
     }
 
     /*! Raise ComplexDouble to power `other`
      * \param other of type Complex
      * */
     RCP<const Number> powcomp(const Complex &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()))));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(i, std::complex<double>(other.real_.get_d(), other.imaginary_.get_d())));
     }
 
     /*! Raise ComplexDouble to power `other`
      * \param other of type RealDouble
      * */
     RCP<const Number> powcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i)));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(i, other.i));
     }
 
 
@@ -390,7 +390,7 @@ public:
      * \param other of type ComplexDouble
      * */
     RCP<const Number> powcomp(const ComplexDouble &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(i, other.i)));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(i, other.i));
     }
 
     //! Converts the param `other` appropriately and then calls `powcomp`
@@ -414,28 +414,28 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> rpowcomp(const Integer &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(other.i.get_d(), i)));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(other.i.get_d(), i));
     }
 
     /*! Raise `other` to power ComplexDouble
      * \param other of type Rational
      * */
     RCP<const Number> rpowcomp(const Rational &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(other.i.get_d(), i)));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(other.i.get_d(), i));
     }
 
     /*! Raise `other` to power ComplexDouble
      * \param other of type Complex
      * */
     RCP<const Number> rpowcomp(const Complex &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()), i)));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(std::complex<double>(other.real_.get_d(), other.imaginary_.get_d()), i));
     }
 
     /*! Raise `other` to power ComplexDouble
      * \param other of type RealDouble
      * */
     RCP<const Number> rpowcomp(const RealDouble &other) const {
-        return rcp(new ComplexDouble((std::complex<double>)std::pow(other.i, i)));
+        return make_rcp<const ComplexDouble>((std::complex<double>)std::pow(other.i, i));
     }
 
     //! Converts the param `other` appropriately and then calls `powcomp`

--- a/symengine/constants.h
+++ b/symengine/constants.h
@@ -53,7 +53,7 @@ public:
 //! inline version to return `Constant`
 inline RCP<const Constant> constant(const std::string &name)
 {
-    return rcp(new Constant(name));
+    return make_rcp<const Constant>(name);
 }
 
 // Constant Numbers

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -274,12 +274,12 @@ RCP<const Basic> TrigFunction::create(const RCP<const Basic> &arg) const
 
 RCP<const Basic> TrigFunction::subs(const map_basic_basic &subs_dict) const
 {
-    auto it = subs_dict.find(rcp(this));
+    auto it = subs_dict.find(get_rcp());
     if (it != subs_dict.end())
         return it->second;
     RCP<const Basic> arg = arg_->subs(subs_dict);
     if (arg == arg_)
-        return rcp(this);
+        return get_rcp();
     else
         return this->create(arg);
 }
@@ -1442,7 +1442,7 @@ int FunctionSymbol::compare(const Basic &o) const
 RCP<const Basic> FunctionSymbol::diff(const RCP<const Symbol> &x) const
 {
     RCP<const Basic> diff = zero, t;
-    RCP<const Basic> self = rcp(this);
+    RCP<const Basic> self = get_rcp();
     RCP<const Symbol> s;
     std::string name;
     unsigned count  = 0;
@@ -1478,7 +1478,7 @@ RCP<const Basic> FunctionSymbol::diff(const RCP<const Symbol> &x) const
 
 RCP<const Basic> FunctionSymbol::subs(const map_basic_basic &subs_dict) const
 {
-    auto it = subs_dict.find(rcp(this));
+    auto it = subs_dict.find(get_rcp());
     if (it != subs_dict.end())
         return it->second;
     vec_basic v = arg_;
@@ -1540,7 +1540,7 @@ RCP<const Basic> FunctionWrapper::diff(const RCP<const Symbol> &x) const
 {
     for (auto &a : arg_) {
         if (neq(a->diff(x), zero)) {
-            return rcp(new Derivative(rcp(this), {x}));
+            return rcp(new Derivative(get_rcp(), {x}));
         }
     }
     return zero;
@@ -1627,7 +1627,7 @@ RCP<const Basic> Derivative::subs(const map_basic_basic &subs_dict) const
     RCP<const Symbol> s;
     map_basic_basic m, n;
     bool subs;
-    auto it = subs_dict.find(rcp(this));
+    auto it = subs_dict.find(get_rcp());
     if (it != subs_dict.end())
         return it->second;
     for (auto &p: subs_dict) {
@@ -1652,7 +1652,7 @@ RCP<const Basic> Derivative::subs(const map_basic_basic &subs_dict) const
                     break;
                 }
             } else {
-                return rcp(new Subs(rcp(this), subs_dict));
+                return rcp(new Subs(get_rcp(), subs_dict));
             }
         }
         if (subs) {
@@ -1757,7 +1757,7 @@ RCP<const Basic> Subs::diff(const RCP<const Symbol> &x) const
             if (is_a<Symbol>(*p.first)) {
                 diff = add(diff, mul(t, arg_->diff(rcp_static_cast<const Symbol>(p.first))->subs(dict_)));
             } else {
-                return rcp(new Derivative(rcp(this), {x}));
+                return rcp(new Derivative(get_rcp(), {x}));
             }
         }
     }
@@ -1801,12 +1801,12 @@ RCP<const Basic> HyperbolicFunction::create(const RCP<const Basic> &arg) const
 
 RCP<const Basic> HyperbolicFunction::subs(const map_basic_basic &subs_dict) const
 {
-    auto it = subs_dict.find(rcp(this));
+    auto it = subs_dict.find(get_rcp());
     if (it != subs_dict.end())
         return it->second;
     RCP<const Basic> arg = arg_->subs(subs_dict);
     if (arg == arg_)
-        return rcp(this);
+        return get_rcp();
     else
         return this->create(arg);
 }
@@ -2962,7 +2962,7 @@ RCP<const Basic> Abs::diff(const RCP<const Symbol> &x) const
     if (eq(arg_->diff(x), zero))
         return zero;
     else
-        return rcp(new Derivative(rcp(this), {x}));
+        return rcp(new Derivative(get_rcp(), {x}));
 }
 
 RCP<const Basic> abs(const RCP<const Basic> &arg)

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -352,7 +352,7 @@ RCP<const Basic> sin(const RCP<const Basic> &arg)
                 if (neq(ret_arg, arg)) {
                     return sin(ret_arg);
                 } else {
-                    return rcp(new Sin(arg));
+                    return make_rcp<const Sin>(arg);
                 }
             } else {
                 return mul(minus_one, sin(ret_arg));
@@ -429,7 +429,7 @@ RCP<const Basic> cos(const RCP<const Basic> &arg)
                 if (neq(ret_arg, arg)) {
                     return cos(ret_arg);
                 } else {
-                    return rcp(new Cos(ret_arg));
+                    return make_rcp<const Cos>(ret_arg);
                 }
             } else {
                 return mul(minus_one, cos(ret_arg));
@@ -509,7 +509,7 @@ RCP<const Basic> tan(const RCP<const Basic> &arg)
                 if (neq(ret_arg, arg)) {
                     return tan(ret_arg);
                 } else {
-                    return rcp(new Tan(ret_arg));
+                    return make_rcp<const Tan>(ret_arg);
                 }
             } else {
                 return mul(minus_one, tan(ret_arg));
@@ -589,7 +589,7 @@ RCP<const Basic> cot(const RCP<const Basic> &arg)
                 if (neq(ret_arg, arg)) {
                     return cot(ret_arg);
                 } else {
-                    return rcp(new Cot(ret_arg));
+                    return make_rcp<const Cot>(ret_arg);
                 }
             } else {
                 return mul(minus_one, cot(ret_arg));
@@ -669,7 +669,7 @@ RCP<const Basic> csc(const RCP<const Basic> &arg)
                 if (neq(ret_arg, arg)) {
                     return csc(ret_arg);
                 } else {
-                    return rcp(new Csc(ret_arg));
+                    return make_rcp<const Csc>(ret_arg);
                 }
             } else {
                 return mul(minus_one, csc(ret_arg));
@@ -748,7 +748,7 @@ RCP<const Basic> sec(const RCP<const Basic> &arg)
                 if (neq(ret_arg, arg)) {
                     return sec(ret_arg);
                 } else {
-                    return rcp(new Sec(ret_arg));
+                    return make_rcp<const Sec>(ret_arg);
                 }
             } else {
                 return mul(minus_one, sec(ret_arg));
@@ -809,7 +809,7 @@ RCP<const Basic> asin(const RCP<const Basic> &arg)
     if (b) {
         return div(pi, index);
     } else {
-        return rcp(new ASin(arg));
+        return make_rcp<const ASin>(arg);
     }
 }
 
@@ -870,7 +870,7 @@ RCP<const Basic> acos(const RCP<const Basic> &arg)
             return sub(div(pi, i2), div(pi, index));
         }
     } else {
-        return rcp(new ACos(arg));
+        return make_rcp<const ACos>(arg);
     }
 }
 
@@ -928,7 +928,7 @@ RCP<const Basic> asec(const RCP<const Basic> &arg)
             return sub(div(pi, i2), div(pi, index));
         }
     } else {
-        return rcp(new ASec(arg));
+        return make_rcp<const ASec>(arg);
     }
 }
 
@@ -982,7 +982,7 @@ RCP<const Basic> acsc(const RCP<const Basic> &arg)
     if (b) {
         return div(pi, index);
     } else {
-        return rcp(new ACsc(arg));
+        return make_rcp<const ACsc>(arg);
     }
 }
 
@@ -1037,7 +1037,7 @@ RCP<const Basic> atan(const RCP<const Basic> &arg)
     if (b) {
         return div(pi, index);
     } else {
-        return rcp(new ATan(arg));
+        return make_rcp<const ATan>(arg);
     }
 }
 
@@ -1097,7 +1097,7 @@ RCP<const Basic> acot(const RCP<const Basic> &arg)
             return sub(div(pi, i2), div(pi, index));
         }
     } else {
-        return rcp(new ACot(arg));
+        return make_rcp<const ACot>(arg);
     }
 }
 
@@ -1206,7 +1206,7 @@ RCP<const Basic> atan2(const RCP<const Basic> &num, const RCP<const Basic> &den)
             return div(pi, index);
         }
     } else {
-        return rcp(new ATan2(num, den));
+        return make_rcp<const ATan2>(num, den);
     }
 }
 
@@ -1391,7 +1391,7 @@ RCP<const Basic> lambertw(const RCP<const Basic> &arg)
     if (eq(arg, E)) return one;
     if (eq(arg, div(one, E))) return minus_one;
     if (eq(arg, div(log(i2), im2))) return mul(minus_one, log(i2));
-    return rcp(new LambertW(arg));
+    return make_rcp<const LambertW>(arg);
 }
 
 FunctionSymbol::FunctionSymbol(std::string name, const RCP<const Basic> &arg)
@@ -1456,7 +1456,7 @@ RCP<const Basic> FunctionSymbol::diff(const RCP<const Symbol> &x) const
         }
     }
     if (count == 1 && found_x) {
-        return rcp(new Derivative(self, {x}));
+        return Derivative::create(self, {x});
     }
     for (unsigned i = 0; i < arg_.size(); i++) {
         t = arg_[i]->diff(x);
@@ -1470,7 +1470,7 @@ RCP<const Basic> FunctionSymbol::diff(const RCP<const Symbol> &x) const
             v[i] = s;
             map_basic_basic m;
             insert(m, v[i], arg_[i]);
-            diff = add(diff, mul(t, rcp(new Subs(rcp(new Derivative(rcp(new FunctionSymbol(name_, v)), {v[i]})), m))));
+            diff = add(diff, mul(t, make_rcp<const Subs>(Derivative::create(make_rcp<const FunctionSymbol>(name_, v), {v[i]}), m)));
         }
     }
     return diff;
@@ -1485,17 +1485,17 @@ RCP<const Basic> FunctionSymbol::subs(const map_basic_basic &subs_dict) const
     for (unsigned i = 0; i < v.size(); i++) {
         v[i] = v[i]->subs(subs_dict);
     }
-    return rcp(new FunctionSymbol(name_, v));
+    return make_rcp<const FunctionSymbol>(name_, v);
 }
 
 RCP<const Basic> function_symbol(std::string name, const vec_basic &arg)
 {
-    return rcp(new FunctionSymbol(name, arg));
+    return make_rcp<const FunctionSymbol>(name, arg);
 }
 
 RCP<const Basic> function_symbol(std::string name, const RCP<const Basic> &arg)
 {
-    return rcp(new FunctionSymbol(name, arg));
+    return make_rcp<const FunctionSymbol>(name, arg);
 }
 
 FunctionWrapper::FunctionWrapper(void* obj, std::string name, std::string hash, const vec_basic &arg, 
@@ -1540,7 +1540,7 @@ RCP<const Basic> FunctionWrapper::diff(const RCP<const Symbol> &x) const
 {
     for (auto &a : arg_) {
         if (neq(a->diff(x), zero)) {
-            return rcp(new Derivative(get_rcp(), {x}));
+            return Derivative::create(get_rcp(), {x});
         }
     }
     return zero;
@@ -1619,7 +1619,7 @@ RCP<const Basic> Derivative::diff(const RCP<const Symbol> &x) const
     if (eq(arg_->diff(x), zero)) return zero;
     vec_basic t = x_;
     t.push_back(x);
-    return rcp(new Derivative(arg_, t));
+    return Derivative::create(arg_, t);
 }
 
 RCP<const Basic> Derivative::subs(const map_basic_basic &subs_dict) const
@@ -1652,7 +1652,7 @@ RCP<const Basic> Derivative::subs(const map_basic_basic &subs_dict) const
                     break;
                 }
             } else {
-                return rcp(new Subs(get_rcp(), subs_dict));
+                return make_rcp<const Subs>(get_rcp(), subs_dict);
             }
         }
         if (subs) {
@@ -1666,9 +1666,9 @@ RCP<const Basic> Derivative::subs(const map_basic_basic &subs_dict) const
         sym[i] = sym[i]->subs(n);
     }
     if (m.empty()) {
-        return rcp(new Derivative(arg_->subs(n), sym));
+        return Derivative::create(arg_->subs(n), sym);
     } else {
-         return rcp(new Subs(rcp(new Derivative(arg_->subs(n), sym)), m));
+         return make_rcp<const Subs>(Derivative::create(arg_->subs(n), sym), m);
     }
 }
 
@@ -1757,7 +1757,7 @@ RCP<const Basic> Subs::diff(const RCP<const Symbol> &x) const
             if (is_a<Symbol>(*p.first)) {
                 diff = add(diff, mul(t, arg_->diff(rcp_static_cast<const Symbol>(p.first))->subs(dict_)));
             } else {
-                return rcp(new Derivative(get_rcp(), {x}));
+                return Derivative::create(get_rcp(), {x});
             }
         }
     }
@@ -1784,7 +1784,7 @@ RCP<const Basic> Subs::subs(const map_basic_basic &subs_dict) const
     for (auto &s: dict_) {
         insert(m, s.first, s.second->subs(subs_dict));
     }
-    return rcp(new Subs(arg_->subs(n), m));
+    return make_rcp<const Subs>(arg_->subs(n), m);
 }
 
 std::size_t HyperbolicFunction::__hash__() const
@@ -1864,7 +1864,7 @@ RCP<const Basic> sinh(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return neg(sinh(neg(arg)));
     }
-    return rcp(new Sinh(arg));
+    return make_rcp<const Sinh>(arg);
 }
 
 RCP<const Basic>  Sinh::expand_as_exp() const
@@ -1930,7 +1930,7 @@ RCP<const Basic> cosh(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return cosh(neg(arg));
     }
-    return rcp(new Cosh(arg));
+    return make_rcp<const Cosh>(arg);
 }
 
 RCP<const Basic>  Cosh::expand_as_exp() const
@@ -1996,7 +1996,7 @@ RCP<const Basic> tanh(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return neg(tanh(neg(arg)));
     }
-    return rcp(new Tanh(arg));
+    return make_rcp<const Tanh>(arg);
 }
 
 RCP<const Basic>  Tanh::expand_as_exp() const
@@ -2067,7 +2067,7 @@ RCP<const Basic> coth(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return neg(coth(neg(arg)));
     }
-    return rcp(new Coth(arg));
+    return make_rcp<const Coth>(arg);
 }
 
 RCP<const Basic>  Coth::expand_as_exp() const
@@ -2137,7 +2137,7 @@ RCP<const Basic> asinh(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return neg(asinh(neg(arg)));
     }
-    return rcp(new ASinh(arg));
+    return make_rcp<const ASinh>(arg);
 }
 
 RCP<const Basic> ASinh::diff(const RCP<const Symbol> &x) const
@@ -2186,7 +2186,7 @@ RCP<const Basic> acosh(const RCP<const Basic> &arg)
     if (is_a_Number(*arg) && !static_cast<const Number &>(*arg).is_exact()) {
         return static_cast<const Number &>(*arg).get_eval().acosh(*arg);
     }
-    return rcp(new ACosh(arg));
+    return make_rcp<const ACosh>(arg);
 }
 
 RCP<const Basic> ACosh::diff(const RCP<const Symbol> &x) const
@@ -2247,7 +2247,7 @@ RCP<const Basic> atanh(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return neg(atanh(neg(arg)));
     }
-    return rcp(new ATanh(arg));
+    return make_rcp<const ATanh>(arg);
 }
 
 RCP<const Basic> ATanh::diff(const RCP<const Symbol> &x) const
@@ -2305,7 +2305,7 @@ RCP<const Basic> acoth(const RCP<const Basic> &arg)
     if (could_extract_minus(arg)) {
         return neg(acoth(neg(arg)));
     }
-    return rcp(new ACoth(arg));
+    return make_rcp<const ACoth>(arg);
 }
 
 RCP<const Basic> ACoth::diff(const RCP<const Symbol> &x) const
@@ -2348,7 +2348,7 @@ RCP<const Basic> asech(const RCP<const Basic> &arg)
 {
     // TODO: Lookup into a cst table once complex is implemented
     if (eq(arg, one)) return zero;
-    return rcp(new ASech(arg));
+    return make_rcp<const ASech>(arg);
 }
 
 RCP<const Basic> ASech::diff(const RCP<const Symbol> &x) const
@@ -2455,7 +2455,7 @@ RCP<const Basic> kronecker_delta(const RCP<const Basic> &i, const RCP<const Basi
         return zero;
     } else {
         // SymPy uses default key sorting to return in order
-        return rcp(new KroneckerDelta(i, j));
+        return make_rcp<const KroneckerDelta>(i, j);
     }
 }
 
@@ -2556,7 +2556,7 @@ RCP<const Basic> levi_civita(const vec_basic &arg)
     } else if (has_dup(arg)) {
         return zero;
     } else {
-        return rcp(new LeviCivita(std::move(arg)));
+        return make_rcp<const LeviCivita>(std::move(arg));
     }
 }
 
@@ -2622,10 +2622,10 @@ RCP<const Basic> zeta(const RCP<const Basic> &s, const RCP<const Basic> &a)
             throw std::runtime_error("Complex infinity is not yet implemented");
         } else if (is_a<Integer>(*s) && is_a<Integer>(*a)) {
             // Implement Harmonic and simplify this
-            return rcp(new Zeta(s, a));
+            return make_rcp<const Zeta>(s, a);
         }
     }
-    return rcp(new Zeta(s, a));
+    return make_rcp<const Zeta>(s, a);
 }
 
 RCP<const Basic> zeta(const RCP<const Basic> &s)
@@ -2680,7 +2680,7 @@ RCP<const Basic> dirichlet_eta(const RCP<const Basic> &s)
     }
     RCP<const Basic> z = zeta(s);
     if (is_a<Zeta>(*z)) {
-        return rcp(new Dirichlet_eta(s));
+        return make_rcp<const Dirichlet_eta>(s);
     } else {
         return mul(sub(one, pow(i2, sub(one, s))), z);
     }
@@ -2765,12 +2765,12 @@ RCP<const Basic> gamma(const RCP<const Basic> &arg)
                 return div(mul(pow(i2, n), sqrt(pi)), coeff);
             }
         } else {
-            return rcp(new Gamma(arg));
+            return make_rcp<const Gamma>(arg);
         }
     } else if (is_a_Number(*arg) && !static_cast<const Number &>(*arg).is_exact()) {
         return static_cast<const Number &>(*arg).get_eval().gamma(*arg);
     }
-    return rcp(new Gamma(arg));
+    return make_rcp<const Gamma>(arg);
 }
 
 LowerGamma::LowerGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
@@ -2830,7 +2830,7 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
             s_int = s_int->subint(*one);
             return sub(mul(s_int, lowergamma(s_int, x)), mul(pow(x, s_int), exp(mul(minus_one, x))));
         } else {
-            return rcp(new LowerGamma(s, x));
+            return make_rcp<const LowerGamma>(s, x);
         }
     } else if (is_a<Integer>(*(mul(i2, s)))) {
         // TODO: Implement `erf`. Currently the recursive expansion has no base case
@@ -2843,7 +2843,7 @@ RCP<const Basic> lowergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
             return add(lowergamma(add(s, one), x), mul(pow(x, s), div(exp(mul(minus_one, x)), s)));
         }
     }
-    return rcp(new LowerGamma(s, x));
+    return make_rcp<const LowerGamma>(s, x);
 }
 
 UpperGamma::UpperGamma(const RCP<const Basic> &s, const RCP<const Basic> &x)
@@ -2904,7 +2904,7 @@ RCP<const Basic> uppergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
             return add(mul(s_int, uppergamma(s_int, x)), mul(pow(x, s_int), exp(mul(minus_one, x))));
         } else {
             // TODO: implement unpolarfy to handle this case
-            return rcp(new LowerGamma(s, x));
+            return make_rcp<const LowerGamma>(s, x);
         }
     } else if (is_a<Integer>(*(mul(i2, s)))) {
         // TODO: Implement `erf`. Currently the recursive expansion has no base case
@@ -2917,7 +2917,7 @@ RCP<const Basic> uppergamma(const RCP<const Basic> &s, const RCP<const Basic> &x
             return sub(uppergamma(add(s, one), x), mul(pow(x, s), div(exp(mul(minus_one, x)), s)));
         }
     }
-    return rcp(new UpperGamma(s, x));
+    return make_rcp<const UpperGamma>(s, x);
 }
 
 
@@ -2962,7 +2962,7 @@ RCP<const Basic> Abs::diff(const RCP<const Symbol> &x) const
     if (eq(arg_->diff(x), zero))
         return zero;
     else
-        return rcp(new Derivative(get_rcp(), {x}));
+        return Derivative::create(get_rcp(), {x});
 }
 
 RCP<const Basic> abs(const RCP<const Basic> &arg)
@@ -2985,7 +2985,7 @@ RCP<const Basic> abs(const RCP<const Basic> &arg)
     } else if (is_a_Number(*arg) && !static_cast<const Number &>(*arg).is_exact()) {
         return static_cast<const Number &>(*arg).get_eval().abs(*arg);
     }
-    return rcp(new Abs(arg));
+    return make_rcp<const Abs>(arg);
 }
 
 } // SymEngine

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -605,6 +605,12 @@ private:
 public:
     IMPLEMENT_TYPEID(DERIVATIVE)
     Derivative(const RCP<const Basic> &arg, const vec_basic &x);
+
+    static RCP<const Derivative> create(const RCP<const Basic> &arg,
+            const vec_basic &x) {
+        return make_rcp<const Derivative>(arg, x);
+    }
+
     virtual std::size_t __hash__() const;
     virtual bool __eq__(const Basic &o) const;
     virtual int compare(const Basic &o) const;

--- a/symengine/functions.h
+++ b/symengine/functions.h
@@ -644,6 +644,12 @@ public:
 public:
     IMPLEMENT_TYPEID(SUBS)
     Subs(const RCP<const Basic> &arg, const map_basic_basic &x);
+
+    static RCP<const Subs> create(const RCP<const Basic> &arg,
+            const map_basic_basic &x) {
+        return make_rcp<const Subs>(arg, x);
+    }
+
     virtual std::size_t __hash__() const;
     virtual bool __eq__(const Basic &o) const;
     virtual int compare(const Basic &o) const;

--- a/symengine/integer.cpp
+++ b/symengine/integer.cpp
@@ -78,7 +78,7 @@ RCP<const Number> Integer::pow_negint(const Integer &other) const {
     RCP<const Number> tmp = powint(*other.neg());
     if (is_a<Integer>(*tmp)) {
         mpq_class q(sgn(rcp_static_cast<const Integer>(tmp)->i), abs(rcp_static_cast<const Integer>(tmp)->i));
-        return rcp(new Rational(q));
+        return make_rcp<const Rational>(q);
     } else {
         throw std::runtime_error("powint returned non-integer");
     }

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -161,7 +161,7 @@ inline RCP<const Integer> integer(int i)
 //! \return RCP<const Integer> from `mpz_class`
 inline RCP<const Integer> integer(mpz_class i)
 {
-    return rcp(new Integer(i));
+    return make_rcp<const Integer>(i);
 }
 //! Integer Square root
 RCP<const Integer> isqrt(const Integer &n);

--- a/symengine/integer.h
+++ b/symengine/integer.h
@@ -51,15 +51,15 @@ public:
     /* These are very fast methods for add/sub/mul/div/pow on Integers only */
     //! Fast Integer Addition
     inline RCP<const Integer> addint(const Integer &other) const {
-        return rcp(new Integer(this->i + other.i));
+        return make_rcp<const Integer>(this->i + other.i);
     }
     //! Fast Integer Subtraction
     inline RCP<const Integer> subint(const Integer &other) const {
-        return rcp(new Integer(this->i - other.i));
+        return make_rcp<const Integer>(this->i - other.i);
     }
     //! Fast Integer Multiplication
     inline RCP<const Integer> mulint(const Integer &other) const {
-        return rcp(new Integer(this->i * other.i));
+        return make_rcp<const Integer>(this->i * other.i);
     }
     //!  Integer Division
     RCP<const Number> divint(const Integer &other) const;
@@ -75,11 +75,11 @@ public:
         }
         mpz_class tmp;
         mpz_pow_ui(tmp.get_mpz_t(), this->i.get_mpz_t(), other.i.get_ui());
-        return rcp(new Integer(tmp));
+        return make_rcp<const Integer>(tmp);
     }
     //! \return negative of self.
     inline RCP<const Integer> neg() const {
-        return rcp(new Integer(-i));
+        return make_rcp<const Integer>(-i);
     }
 
     /* These are general methods, overriden from the Number class, that need to
@@ -155,7 +155,7 @@ struct RCPIntegerKeyLess
 //! \return RCP<const Integer> from `int`
 inline RCP<const Integer> integer(int i)
 {
-    return rcp(new Integer(i));
+    return make_rcp<const Integer>(i);
 }
 
 //! \return RCP<const Integer> from `mpz_class`

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -118,17 +118,17 @@ RCP<const SymEngine::Basic> Mul::from_dict(const RCP<const Number> &coef, map_ba
                 }
             } else {
                 // For coef*x or coef*x**3 we simply return Mul:
-                return rcp(new Mul(coef, std::move(d)));
+                return make_rcp<const Mul>(coef, std::move(d));
             }
         }
         if (coef->is_one()) {
             // Create a Pow() here:
             return pow(p->first, p->second);
         } else {
-            return rcp(new Mul(coef, std::move(d)));
+            return make_rcp<const Mul>(coef, std::move(d));
         }
     } else {
-        return rcp(new Mul(coef, std::move(d)));
+        return make_rcp<const Mul>(coef, std::move(d));
     }
 }
 

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -524,7 +524,7 @@ RCP<const Basic> Mul::diff(const RCP<const Symbol> &x) const
 
 RCP<const Basic> Mul::subs(const map_basic_basic &subs_dict) const
 {
-    RCP<const Mul> self = rcp_const_cast<Mul>(rcp(this));
+    RCP<const Mul> self = get_rcp_cast<const Mul>();
     auto it = subs_dict.find(self);
     if (it != subs_dict.end())
         return it->second;

--- a/symengine/polynomial.cpp
+++ b/symengine/polynomial.cpp
@@ -95,7 +95,7 @@ RCP<const Basic> UnivariatePolynomial::from_dict(const RCP<const Symbol> &var, m
                     {{var, integer(d.begin()->first)}});
         }
     } else {
-        return rcp(new UnivariatePolynomial(var, (--(d.end()))->first, std::move(d)));
+        return make_rcp<const UnivariatePolynomial>(var, (--(d.end()))->first, std::move(d));
     }
 }
 
@@ -130,7 +130,7 @@ RCP<const Basic> UnivariatePolynomial::diff(const RCP<const Symbol> &x) const
         for (auto &p : dict_) {
             d[p.first - 1] = p.second * p.first;
         }
-        return rcp(new UnivariatePolynomial(var_, (--(d.end()))->first, std::move(d)));
+        return make_rcp<const UnivariatePolynomial>(var_, (--(d.end()))->first, std::move(d));
     } else
         return zero;
 }
@@ -289,9 +289,9 @@ RCP<const UnivariatePolynomial> mul_uni_poly(RCP<const UnivariatePolynomial> a, 
     }
 
     if (sign == -1)
-        return neg_uni_poly(*rcp(new UnivariatePolynomial(a->var_, v)));
+        return neg_uni_poly(*make_rcp<const UnivariatePolynomial>(a->var_, v));
     else
-        return rcp(new UnivariatePolynomial(a->var_, v));
+        return make_rcp<const UnivariatePolynomial>(a->var_, v);
 }
 
 } // SymEngine

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -29,6 +29,12 @@ public:
     UnivariatePolynomial(const RCP<const Symbol> &var, const unsigned int &degree, map_uint_mpz&& dict);
     //! Constructor using a dense vector of mpz_class coefficients
     UnivariatePolynomial(const RCP<const Symbol> &var, const std::vector<mpz_class> &v);
+
+    static RCP<const UnivariatePolynomial> create(const RCP<const Symbol> &var,
+            const std::vector<mpz_class> &v) {
+        return make_rcp<const UnivariatePolynomial>(var, v);
+    }
+
     //! \return true if canonical
     bool is_canonical(const unsigned int &degree, const map_uint_mpz& dict);
     //! \return size of the hash

--- a/symengine/polynomial.h
+++ b/symengine/polynomial.h
@@ -89,7 +89,7 @@ RCP<const UnivariatePolynomial> mul_uni_poly(RCP<const UnivariatePolynomial> a, 
 
 inline RCP<const UnivariatePolynomial> univariate_polynomial(RCP<const Symbol> i, unsigned int deg, map_uint_mpz&& dict)
 {
-    return rcp(new UnivariatePolynomial(i, deg, std::move(dict)));
+    return make_rcp<const UnivariatePolynomial>(i, deg, std::move(dict));
 }
 
 }  //SymEngine

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -135,7 +135,7 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
                 if (is_a_Number(*a) && !rcp_static_cast<const Number>(a)->is_exact()) {
                     return rcp_static_cast<const Number>(a)->pow(*rcp_static_cast<const Number>(b));
                 }
-                return rcp(new Pow(a, b));
+                return make_rcp<const Pow>(a, b);
             }
             // Here we make the exponent postive and a fraction between
             // 0 and 1. We multiply numerator and denominator appropriately
@@ -145,8 +145,8 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
                 RCP<const Basic> frac =
                     div(exp_new->powrat(Integer(q)), integer(exp_new->i.get_den()));
                 RCP<const Basic> surds =
-                    mul(rcp(new Pow(integer(exp_new->i.get_num()), div(integer(r), integer(den)))),
-                        rcp(new Pow(integer(exp_new->i.get_den()), sub(one, div(integer(r), integer(den))))));
+                    mul(make_rcp<const Pow>(integer(exp_new->i.get_num()), div(integer(r), integer(den))),
+                        make_rcp<const Pow>(integer(exp_new->i.get_den()), sub(one, div(integer(r), integer(den)))));
                 return mul(frac, surds);
             } else if (is_a<Integer>(*a)) {
                 RCP<const Integer> exp_new = rcp_static_cast<const Integer>(a);
@@ -162,14 +162,14 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
                 } else {
                     surd[exp_new] = div(integer(r), integer(den));
                 }
-                return rcp(new Mul(frac, std::move(surd)));
+                return make_rcp<const Mul>(frac, std::move(surd));
             } else if (is_a<Complex>(*a)) {
-                return rcp(new Pow(a, b));
+                return make_rcp<const Pow>(a, b);
             } else {
                 return rcp_static_cast<const Number>(a)->pow(*rcp_static_cast<const Number>(b));
             }
         } else if (is_a<Complex>(*b)) {
-            return rcp(new Pow(a, b));
+            return make_rcp<const Pow>(a, b);
         } else {
             return rcp_static_cast<const Number>(a)->pow(*rcp_static_cast<const Number>(b));
         }
@@ -185,7 +185,7 @@ RCP<const Basic> pow(const RCP<const Basic> &a, const RCP<const Basic> &b)
         RCP<const Pow> A = rcp_static_cast<const Pow>(a);
         return pow(A->base_, mul(A->exp_, b));
     }
-    return rcp(new Pow(a, b));
+    return make_rcp<const Pow>(a, b);
 }
 
 // This function can overflow, but it is fast.
@@ -514,7 +514,7 @@ RCP<const Basic> log(const RCP<const Basic> &arg)
         get_num_den(rcp_static_cast<const Rational>(arg), outArg(num), outArg(den));
         return sub(log(num), log(den));
     }
-    return rcp(new Log(arg));
+    return make_rcp<const Log>(arg);
 }
 
 RCP<const Basic> log(const RCP<const Basic> &arg, const RCP<const Basic> &base)

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -402,7 +402,7 @@ RCP<const Basic> Pow::diff(const RCP<const Symbol> &x) const
 
 RCP<const Basic> Pow::subs(const map_basic_basic &subs_dict) const
 {
-    RCP<const Pow> self = rcp_const_cast<Pow>(rcp(this));
+    RCP<const Pow> self = get_rcp_cast<const Pow>();
     auto it = subs_dict.find(self);
     if (it != subs_dict.end())
         return it->second;
@@ -477,7 +477,7 @@ int Log::compare(const Basic &o) const
 
 RCP<const Basic> Log::subs(const map_basic_basic &subs_dict) const
 {
-    RCP<const Log> self = rcp_const_cast<Log>(rcp(this));
+    RCP<const Log> self = get_rcp_cast<const Log>();
     auto it = subs_dict.find(self);
     if (it != subs_dict.end())
         return it->second;

--- a/symengine/rational.cpp
+++ b/symengine/rational.cpp
@@ -26,7 +26,7 @@ RCP<const Number> Rational::from_mpq(const mpq_class i)
     if (i.get_den() == 1) {
         return integer(i.get_num());
     } else {
-        return rcp(new Rational(i));
+        return make_rcp<const Rational>(i);
     }
 }
 

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -149,12 +149,12 @@ public:
             if (abs(den) == one->i)
                 return integer(num*sgn(den));
             else
-                return rcp(new Rational(mpq_class(num*sgn(den), abs(den))));
+                return make_rcp<const Rational>(mpq_class(num*sgn(den), abs(den)));
         else
             if (abs(num) == one->i)
                 return integer(den*sgn(num));
             else
-                return rcp(new Rational(mpq_class(den*sgn(num), abs(num))));
+                return make_rcp<const Rational>(mpq_class(den*sgn(num), abs(num)));
     }
 
     //! Converts the param `other` appropriately and then calls `addrat`

--- a/symengine/real_double.cpp
+++ b/symengine/real_double.cpp
@@ -37,7 +37,7 @@ int RealDouble::compare(const Basic &o) const
     return i < s.i ? -1 : 1;
 }
 
-RCP<const RealDouble> real_double(double x) { return rcp(new RealDouble(x)); };
+RCP<const RealDouble> real_double(double x) { return make_rcp<const RealDouble>(x); };
 
 RCP<const Number> number(std::complex<double> x) { return complex_double(x); };
 RCP<const Number> number(double x) { return real_double(x); };

--- a/symengine/real_double.h
+++ b/symengine/real_double.h
@@ -63,14 +63,14 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> addreal(const Integer &other) const {
-        return rcp(new RealDouble(i + other.i.get_d()));
+        return make_rcp<const RealDouble>(i + other.i.get_d());
     }
 
     /*! Add RealDoubles
      * \param other of type Rational
      * */
     RCP<const Number> addreal(const Rational &other) const {
-        return rcp(new RealDouble(i + other.i.get_d()));
+        return make_rcp<const RealDouble>(i + other.i.get_d());
     }
 
     /*! Add RealDoubles
@@ -84,7 +84,7 @@ public:
      * \param other of type RealDouble
      * */
     RCP<const Number> addreal(const RealDouble &other) const {
-        return rcp(new RealDouble(i + other.i));
+        return make_rcp<const RealDouble>(i + other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `addreal`
@@ -106,14 +106,14 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> subreal(const Integer &other) const {
-        return rcp(new RealDouble(i - other.i.get_d()));
+        return make_rcp<const RealDouble>(i - other.i.get_d());
     }
 
     /*! Subtract RealDoubles
      * \param other of type Rational
      * */
     RCP<const Number> subreal(const Rational &other) const {
-        return rcp(new RealDouble(i - other.i.get_d()));
+        return make_rcp<const RealDouble>(i - other.i.get_d());
     }
 
     /*! Subtract RealDoubles
@@ -127,7 +127,7 @@ public:
      * \param other of type RealDouble
      * */
     RCP<const Number> subreal(const RealDouble &other) const {
-        return rcp(new RealDouble(i - other.i));
+        return make_rcp<const RealDouble>(i - other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `subreal`
@@ -149,14 +149,14 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> rsubreal(const Integer &other) const {
-        return rcp(new RealDouble(other.i.get_d() - i));
+        return make_rcp<const RealDouble>(other.i.get_d() - i);
     }
 
     /*! Subtract RealDoubles
      * \param other of type Rational
      * */
     RCP<const Number> rsubreal(const Rational &other) const {
-        return rcp(new RealDouble(other.i.get_d() - i));
+        return make_rcp<const RealDouble>(other.i.get_d() - i);
     }
 
     /*! Subtract RealDoubles
@@ -184,14 +184,14 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> mulreal(const Integer &other) const {
-        return rcp(new RealDouble(i * other.i.get_d()));
+        return make_rcp<const RealDouble>(i * other.i.get_d());
     }
 
     /*! Multiply RealDoubles
      * \param other of type Rational
      * */
     RCP<const Number> mulreal(const Rational &other) const {
-        return rcp(new RealDouble(i * other.i.get_d()));
+        return make_rcp<const RealDouble>(i * other.i.get_d());
     }
 
     /*! Multiply RealDoubles
@@ -205,7 +205,7 @@ public:
      * \param other of type RealDouble
      * */
     RCP<const Number> mulreal(const RealDouble &other) const {
-        return rcp(new RealDouble(i * other.i));
+        return make_rcp<const RealDouble>(i * other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `mulreal`
@@ -227,14 +227,14 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> divreal(const Integer &other) const {
-        return rcp(new RealDouble(i / other.i.get_d()));
+        return make_rcp<const RealDouble>(i / other.i.get_d());
     }
 
     /*! Divide RealDoubles
      * \param other of type Rational
      * */
     RCP<const Number> divreal(const Rational &other) const {
-        return rcp(new RealDouble(i / other.i.get_d()));
+        return make_rcp<const RealDouble>(i / other.i.get_d());
     }
 
     /*! Divide RealDoubles
@@ -248,7 +248,7 @@ public:
      * \param other of type RealDouble
      * */
     RCP<const Number> divreal(const RealDouble &other) const {
-        return rcp(new RealDouble(i / other.i));
+        return make_rcp<const RealDouble>(i / other.i);
     }
 
     //! Converts the param `other` appropriately and then calls `divreal`
@@ -270,14 +270,14 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> rdivreal(const Integer &other) const {
-        return rcp(new RealDouble(other.i.get_d() / i));
+        return make_rcp<const RealDouble>(other.i.get_d() / i);
     }
 
     /*! Divide RealDoubles
      * \param other of type Rational
      * */
     RCP<const Number> rdivreal(const Rational &other) const {
-        return rcp(new RealDouble(other.i.get_d() / i));
+        return make_rcp<const RealDouble>(other.i.get_d() / i);
     }
 
     /*! Divide RealDoubles
@@ -304,7 +304,7 @@ public:
      * \param other of type Integer
      * */
     RCP<const Number> powreal(const Integer &other) const {
-        return rcp(new RealDouble(std::pow(i, other.i.get_d())));
+        return make_rcp<const RealDouble>(std::pow(i, other.i.get_d()));
     }
 
     /*! Raise RealDouble to power `other`
@@ -314,7 +314,7 @@ public:
         if (i < 0) {
             return number(std::pow(std::complex<double>(i), other.i.get_d()));
         }
-        return rcp(new RealDouble(std::pow(i, other.i.get_d())));
+        return make_rcp<const RealDouble>(std::pow(i, other.i.get_d()));
     }
 
     /*! Raise RealDouble to power `other`
@@ -331,7 +331,7 @@ public:
         if (i < 0) {
             return number(std::pow(std::complex<double>(i), other.i));
         }
-        return rcp(new RealDouble(std::pow(i, other.i)));
+        return make_rcp<const RealDouble>(std::pow(i, other.i));
     }
 
     //! Converts the param `other` appropriately and then calls `powreal`
@@ -356,7 +356,7 @@ public:
         if (other.is_negative()) {
             return number(std::pow(other.i.get_d(), std::complex<double>(i)));
         }
-        return rcp(new RealDouble(std::pow(other.i.get_d(), i)));
+        return make_rcp<const RealDouble>(std::pow(other.i.get_d(), i));
     }
 
     /*! Raise `other` to power RealDouble
@@ -366,7 +366,7 @@ public:
         if (other.is_negative()) {
             return number(std::pow(std::complex<double>(i), other.i.get_d()));
         }
-        return rcp(new RealDouble(std::pow(other.i.get_d(), i)));
+        return make_rcp<const RealDouble>(std::pow(other.i.get_d(), i));
     }
     
     /*! Raise `other` to power RealDouble

--- a/symengine/symbol.h
+++ b/symengine/symbol.h
@@ -50,7 +50,13 @@ public:
 //! inline version to return `Symbol`
 inline RCP<const Symbol> symbol(const std::string &name)
 {
+#if defined(WITH_SYMENGINE_RCP)
     return rcp(new Symbol(name));
+#else
+    RCP<const Symbol> s = rcp(new Symbol(name));
+    s->weak_self_ptr_ = s.create_weak();
+    return s;
+#endif
 }
 
 } // SymEngine

--- a/symengine/symbol.h
+++ b/symengine/symbol.h
@@ -50,13 +50,7 @@ public:
 //! inline version to return `Symbol`
 inline RCP<const Symbol> symbol(const std::string &name)
 {
-#if defined(WITH_SYMENGINE_RCP)
-    return rcp(new Symbol(name));
-#else
-    RCP<const Symbol> s = rcp(new Symbol(name));
-    s->weak_self_ptr_ = s.create_weak();
-    return s;
-#endif
+    return make_rcp<const Symbol>(name);
 }
 
 } // SymEngine

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -29,6 +29,7 @@ using SymEngine::zero;
 using SymEngine::Number;
 using SymEngine::pow;
 using SymEngine::RCP;
+using SymEngine::make_rcp;
 using SymEngine::print_stack_on_segfault;
 using SymEngine::Complex;
 using SymEngine::has_symbol;
@@ -94,9 +95,9 @@ void test_add()
     insert(m, y, integer(3));
 
     m2 = m;
-    RCP<const Add> a = rcp(new Add(zero, std::move(m2)));
+    RCP<const Add> a = make_rcp<const Add>(zero, std::move(m2));
     insert(m, x, integer(-2));
-    RCP<const Add> b = rcp(new Add(zero, std::move(m)));
+    RCP<const Add> b = make_rcp<const Add>(zero, std::move(m));
     std::cout << *a << std::endl;
     std::cout << *b << std::endl;
 
@@ -283,9 +284,9 @@ void test_mul()
     insert(m, y, integer(3));
 
     m2 = m;
-    RCP<const Mul> a = rcp(new Mul(one, std::move(m2)));
+    RCP<const Mul> a = make_rcp<const Mul>(one, std::move(m2));
     insert(m, x, integer(-2));
-    RCP<const Mul> b = rcp(new Mul(one, std::move(m)));
+    RCP<const Mul> b = make_rcp<const Mul>(one, std::move(m));
     std::cout << *a << std::endl;
     std::cout << *b << std::endl;
 

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -47,6 +47,7 @@ using SymEngine::Derivative;
 using SymEngine::pi;
 using SymEngine::RCP;
 using SymEngine::rcp;
+using SymEngine::make_rcp;
 using SymEngine::print_stack_on_segfault;
 using SymEngine::sqrt;
 using SymEngine::sinh;
@@ -718,77 +719,77 @@ void test_Derivative()
     RCP<const Basic> r1, r2, r3;
 
     r1 = f->diff(x);
-    r2 = rcp(new Derivative(f, {x}));
-    r3 = rcp(new Derivative(g, {x}));
+    r2 = Derivative::create(f, {x});
+    r3 = Derivative::create(g, {x});
     assert(eq(r1, r2));
     assert(neq(r1, r3));
     assert(neq(r2, r3));
     assert(vec_basic_eq(r1->get_args(), {f, x}));
 
     r1 = f->diff(x)->diff(x);
-    r2 = rcp(new Derivative(f, {x, x}));
+    r2 = Derivative::create(f, {x, x});
     assert(eq(r1, r2));
     assert(vec_basic_eq(r1->get_args(), {f, x, x}));
 
     f = function_symbol("f", {x, y});
     r1 = f->diff(x)->diff(y);
-    r2 = rcp(new Derivative(f, {x, y}));
-    r3 = rcp(new Derivative(f, {y, x}));
+    r2 = Derivative::create(f, {x, y});
+    r3 = Derivative::create(f, {y, x});
     assert(eq(r1, r2));
     assert(neq(r1, r3));
 
     f = function_symbol("f", pow(x, integer(2)));
     r1 = f->diff(x);
     std::cout << *f << " " << *r1 << std::endl;
-    r2 = rcp(new Derivative(function_symbol("f", _x), {_x}));
-    r2 = rcp(new Subs(r2, {{_x, pow(x, integer(2))}}));
+    r2 = Derivative::create(function_symbol("f", _x), {_x});
+    r2 = Subs::create(r2, {{_x, pow(x, integer(2))}});
     assert(eq(r1, mul(mul(integer(2), x), r2)));
 
     f = function_symbol("f", {x, x});
     r1 = f->diff(x);
     std::cout << *f << " " << *r1 << std::endl;
-    r2 = rcp(new Derivative(function_symbol("f", {_x, x}), {_x}));
-    r2 = rcp(new Subs(r2, {{_x, x}}));
-    r3 = rcp(new Derivative(function_symbol("f", {x, _x}), {_x}));
-    r3 = rcp(new Subs(r3, {{_x, x}}));
+    r2 = Derivative::create(function_symbol("f", {_x, x}), {_x});
+    r2 = Subs::create(r2, {{_x, x}});
+    r3 = Derivative::create(function_symbol("f", {x, _x}), {_x});
+    r3 = Subs::create(r3, {{_x, x}});
     assert(eq(r1, add(r2, r3)));
 
     f = function_symbol("f", {y, add(x, y)});
     r1 = f->diff(x);
     std::cout << *f << " " << *r1 << std::endl;
-    r2 = rcp(new Derivative(function_symbol("f", {y, _x}), {_x}));
-    r2 = rcp(new Subs(r2, {{_x, add(y, x)}}));
+    r2 = Derivative::create(function_symbol("f", {y, _x}), {_x});
+    r2 = Subs::create(r2, {{_x, add(y, x)}});
     assert(eq(r1, r2));
 
     r1 = function_symbol("f", add(_x, x))->diff(_x);
     std::cout << *f << " " << *r1 << std::endl;
-    r2 = rcp(new Subs(rcp(new Derivative(function_symbol("f", __x), {__x})), {{__x, add(_x, x)}}));
+    r2 = Subs::create(Derivative::create(function_symbol("f", __x), {__x}), {{__x, add(_x, x)}});
     assert(eq(r1, r2));
 
     // Test is_canonical()
     f = function_symbol("f", x);
-    RCP<const Derivative> r4 = rcp(new Derivative(f, {x}));
+    RCP<const Derivative> r4 = Derivative::create(f, {x});
     assert(r4->is_canonical(function_symbol("f", {y, x}), {x}));
     assert(!r4->is_canonical(function_symbol("f", y), {x}));
     assert(r4->is_canonical(function_symbol("f", x), {x, y, x, x}));
     assert(!(r4->is_canonical(function_symbol("f", x), {pow(x, integer(2))})));
 
     // Test get_args()
-    r1 = rcp(new Derivative(function_symbol("f", {x, pow(y, integer(2))}), {x, x, y}));
+    r1 = Derivative::create(function_symbol("f", {x, pow(y, integer(2))}), {x, x, y});
     assert(vec_basic_eq(r1->get_args(), {function_symbol("f", {x, pow(y, integer(2))}), x, x, y}));
 
     // Test Derivative::subs
-    r1 = rcp(new Derivative(function_symbol("f", {x, add(y, y)}), {x}));
+    r1 = Derivative::create(function_symbol("f", {x, add(y, y)}), {x});
     r2 = r1->subs({{x, y}});
-    r3 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {x, add(y, y)}), {x})), {{x, y}}));
+    r3 = Subs::create(Derivative::create(function_symbol("f", {x, add(y, y)}), {x}), {{x, y}});
     assert(eq(r2, r3));
 
     r2 = r1->subs({{x, z}});
-    r3 = rcp(new Derivative(function_symbol("f", {z, add(y, y)}), {z}));
+    r3 = Derivative::create(function_symbol("f", {z, add(y, y)}), {z});
     assert(eq(r2, r3));
 
     r2 = r1->subs({{y, z}});
-    r3 = rcp(new Derivative(function_symbol("f", {x, add(z, z)}), {x}));
+    r3 = Derivative::create(function_symbol("f", {x, add(z, z)}), {x});
     assert(eq(r2, r3));
 }
 
@@ -801,17 +802,17 @@ void test_Subs()
     RCP<const Basic> r1, r2, r3, r4;
 
     // Test Subs::subs
-    r1 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {y, x}), {x})), {{x, add(x, y)}}));
-    r2 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {y, x}), {x})), {{x, z}, {y, z}}));
-    r3 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {y, x}), {x})), {{y, z}, {x, z}}));
+    r1 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}), {{x, add(x, y)}});
+    r2 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}), {{x, z}, {y, z}});
+    r3 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}), {{y, z}, {x, z}});
     assert(eq(r2, r3));
 
     r2 = r1->subs({{y, z}});
-    r3 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {z, x}), {x})), {{x, add(x, z)}}));
+    r3 = Subs::create(Derivative::create(function_symbol("f", {z, x}), {x}), {{x, add(x, z)}});
     assert(eq(r2, r3));
 
     r2 = r1->subs({{x, z}});
-    r3 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {y, x}), {x})), {{x, add(z, y)}}));
+    r3 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}), {{x, add(z, y)}});
     assert(eq(r2, r3));
 
     // Test Subs::diff
@@ -822,15 +823,15 @@ void test_Subs()
     assert(eq(r2, r3));
 
     r2 = r1->diff(x);
-    r3 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {add(y, y), _x}), {_x, _x})), 
-                        {{_x, add(x, y)}}));
+    r3 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, _x}), 
+                        {{_x, add(x, y)}});
     assert(eq(r2, r3));
 
     r2 = r1->diff(y);
-    r3 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {add(y, y), _x}), {_x, _x})), 
-                        {{_x, add(x, y)}}));
-    r4 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {add(y, y), _x}), {_x, y})), 
-                        {{_x, add(x, y)}}));
+    r3 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, _x}), 
+                        {{_x, add(x, y)}});
+    r4 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, y}), 
+                        {{_x, add(x, y)}});
     r3 = add(r3, r4);
     assert(eq(r2, r3));
 }
@@ -1800,7 +1801,7 @@ class DummyFunction {
         }
         RCP<const Basic> getFunctionWrapper() {
             ++count_;
-            return rcp(new FunctionWrapper((void*)this, name_, hash_, args_, &dec_ref, &comp));
+            return make_rcp<const FunctionWrapper>((void*)this, name_, hash_, args_, &dec_ref, &comp);
         }
 };
 

--- a/symengine/tests/basic/test_polynomial.cpp
+++ b/symengine/tests/basic/test_polynomial.cpp
@@ -12,6 +12,7 @@ using SymEngine::Symbol;
 using SymEngine::symbol;
 using SymEngine::Pow;
 using SymEngine::RCP;
+using SymEngine::make_rcp;
 using SymEngine::print_stack_on_segfault;
 using SymEngine::map_uint_mpz;
 using SymEngine::Basic;
@@ -26,7 +27,7 @@ void uni_poly_constructor()
     RCP<const UnivariatePolynomial> P = univariate_polynomial(x, 2, {{0, 1}, {1, 2}, {2, 1}});
     assert(P->__str__() == "x**2 + 2*x + 1");
 
-    RCP<const UnivariatePolynomial> Q = rcp(new UnivariatePolynomial(x, {1, 0, 2, 1}));
+    RCP<const UnivariatePolynomial> Q = UnivariatePolynomial::create(x, {1, 0, 2, 1});
     assert(Q->__str__() == "x**3 + 2*x**2 + 1");
 }
 
@@ -149,7 +150,7 @@ void test_expand()
 {
     RCP<const Symbol> x  = symbol("x");
     RCP<const UnivariatePolynomial> a = univariate_polynomial(x, 3, {{1, 1}, {2, 1}, {3, 1}});
-    RCP<const Basic> b = rcp(new Pow(a, integer(3)));
+    RCP<const Basic> b = make_rcp<const Pow>(a, integer(3));
     RCP<const Basic> c = expand(b);
 
     assert(b->__str__() == "(x**3 + x**2 + x)**3");

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -193,8 +193,8 @@ void test_printing()
     RCP<const Basic> f = function_symbol("f", x);
     RCP<const Basic> g = function_symbol("g", x);
     r = f->diff(x);
-    r1 = rcp(new Derivative(f, {x}));
-    r2 = rcp(new Derivative(g, {x}));
+    r1 = Derivative::create(f, {x});
+    r2 = Derivative::create(g, {x});
 
     assert(r->__str__() == "Derivative(f(x), x)");
     assert(r1->__str__() == "Derivative(f(x), x)");
@@ -205,13 +205,13 @@ void test_printing()
 
     f = function_symbol("f", {x, y});
     r = f->diff(x)->diff(y);
-    r1 = rcp(new Derivative(f, {x, y}));
-    r2 = rcp(new Derivative(f, {y, x}));
+    r1 = Derivative::create(f, {x, y});
+    r2 = Derivative::create(f, {y, x});
     assert(r->__str__() == "Derivative(f(x, y), x, y)");
     assert(r1->__str__() == "Derivative(f(x, y), x, y)");
     assert(r2->__str__() == "Derivative(f(x, y), y, x)");
 
-    r1 = rcp(new Subs(rcp(new Derivative(function_symbol("f", {y, x}), {x})), {{x, add(x, y)}}));
+    r1 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}), {{x, add(x, y)}});
     assert(r1->__str__() == "Subs(Derivative(f(y, x), x), (x), (x + y))");
 }
 

--- a/symengine/visitor.cpp
+++ b/symengine/visitor.cpp
@@ -107,7 +107,7 @@ public:
     FreeSymbolsVisitor() : BaseVisitor(this) { };
 
     void bvisit(const Symbol &x) {
-        s.insert(rcp(&x));
+        s.insert(x.get_rcp());
     }
 
     void bvisit(const Subs &x) {


### PR DESCRIPTION
Now the raw `new` is never used in SymEngine, except in the implementation of `make_rcp`. That way, there is no possibility of a segfault or undefined behavior in Debug mode, since the raw pointer returned by `new` is immediately passed into `rcp`, and one never does this by hand, only by calling `make_rcp`.

The `get_rcp` and `get_rcp_cast` methods return a safe `rcp(this)`. So the new rule is that not only the raw `new` is never used, but also raw `rcp` is never used anymore.

As a bonus, by adding few ifdefs, one can now use Teuchos::RCP in Debug mode and it works. Teuchos::RCP is 100% safe in Debug mode (it has sophisticated dangling pointers and other checks), unlike our own implementation of RCP. In Release mode, we still use our own implementation because it is faster. Now we can get rid of a Debug implementation of our own RCP. Essentially one will use Teuchos::RCP in Debug mode, and only in Release mode one switches to our own implementation.

In Debug mode and if Teuchos::RCP is used, the cwrappers are disabled, I need to look into it if it is possible to enable it. Also the `test_rcp` fails, I need to update it. All other tests pass with Teuchos::RCP, which is quite nontrivial, that has never worked before once we started returning a RCP to this.