### PR TITLE
Make all tests pass with Teuchos::RCP, enable it on Travis and Shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,11 @@ matrix:
     - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: linux
-    - env: BUILD_TYPE="Release" WITH_BFD="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
-      compiler: clang
-      os: linux
+# Clang fails to build due to https://github.com/sympy/symengine/issues/486, so
+# we comment the following test out, until this gets fixed.
+#    - env: BUILD_TYPE="Release" WITH_BFD="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+#      compiler: clang
+#      os: linux
     - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,24 +17,22 @@ env:
   ## Out of tree builds (default):
   # Debug build
   - BUILD_TYPE="Debug"
-  # Debug build (with BFD and SYMENGINE_ASSERT)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with Python 2.7
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
-  # Debug build (with BFD and SYMENGINE_ASSERT and SYMENGINE_THREAD_SAFE)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with ECM
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_ECM="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with PRIMESIEVE
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PRIMESIEVE="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with Arb
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_ARB="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with MPC
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_MPC="yes"
-  # Debug build shared lib (with BFD and SYMENGINE_ASSERT)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" BUILD_SHARED_LIBS="yes"
-  # Debug build with Teuchos::RCP (just to test that it compiles)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_RCP="no"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with Python 2.7
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+  # Debug build (with BFD and SYMENGINE_ASSERT and SYMENGINE_THREAD_SAFE and Teuchos::RCP)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_SYMENGINE_THREAD_SAFE="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with ECM
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_ECM="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with PRIMESIEVE
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PRIMESIEVE="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with Arb
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_ARB="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with MPC
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_MPC="yes"
+  # Debug build shared lib (with BFD and SYMENGINE_ASSERT and Teuchos::RCP)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" BUILD_SHARED_LIBS="yes"
   # Release build (with BFD)
   - WITH_BFD="yes"
 
@@ -42,7 +40,7 @@ env:
   # Debug build without Python:
   - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes"
   # Debug build with Python 2.7:
-  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_SYMENGINE_ASSERT="yes" PYTHON_VERSION="2.7"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" PYTHON_VERSION="2.7"
   # Release build with Python 2.7:
   - TEST_IN_TREE="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
   # Release build shared lib with Python 2.7:
@@ -64,13 +62,22 @@ matrix:
     - compiler: clang
     - os: osx
   include:
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: linux
-    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+    - env: BUILD_TYPE="Release" WITH_BFD="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+      compiler: clang
+      os: linux
+    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: osx
-    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+    - env: BUILD_TYPE="Release" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+      compiler: clang
+      os: osx
+    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+      compiler: gcc
+      os: osx
+    - env: BUILD_TYPE="Release" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: gcc
       os: osx
     - language: ruby

--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ will report at configure time if the Cython version is too old.
 The Travis-CI checks the code in both Release and Debug mode with all possible
 checks, so just sending a GitHub pull request is enough and you can use any
 mode you want to develop it. However, the best way to develop SymEngine is to
-use the Debug mode, turn assertions on and turn `BFD` support on (prints very
-nice stacktraces on exceptions, segfaults or assert errors):
+use the Debug mode, turn assertions and `Teuchos::RCP` on and turn `BFD` support
+on (prints very nice stacktraces on exceptions, segfaults or assert errors):
 
-    cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_SYMENGINE_ASSERT=yes -DWITH_BFD=yes .
+    cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_SYMENGINE_ASSERT=yes \
+        -DWITH_SYMENGINE_RCP=no -DWITH_BFD=yes .
 
 To make `WITH_BFD=yes` work, you need to install `binutils-dev` first,
 otherwise you will get a `CMake` error during configuring.

--- a/benchmarks/add1.cpp
+++ b/benchmarks/add1.cpp
@@ -21,7 +21,6 @@ using SymEngine::map_vec_int;
 using SymEngine::integer;
 using SymEngine::multinomial_coefficients;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 
 int main(int argc, char* argv[])

--- a/benchmarks/eval_double1.cpp
+++ b/benchmarks/eval_double1.cpp
@@ -24,7 +24,6 @@ using SymEngine::map_vec_int;
 using SymEngine::Integer;
 using SymEngine::multinomial_coefficients;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 using SymEngine::integer;
 using SymEngine::sin;

--- a/benchmarks/expand1.cpp
+++ b/benchmarks/expand1.cpp
@@ -24,7 +24,6 @@ using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::multinomial_coefficients;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 
 int main(int argc, char* argv[])

--- a/benchmarks/expand2.cpp
+++ b/benchmarks/expand2.cpp
@@ -23,7 +23,6 @@ using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::multinomial_coefficients;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 
 int main(int argc, char* argv[])

--- a/benchmarks/expand2b.cpp
+++ b/benchmarks/expand2b.cpp
@@ -21,7 +21,6 @@ using SymEngine::expr2poly;
 using SymEngine::poly_mul;
 using SymEngine::umap_vec_mpz;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::print_stack_on_segfault;
 
 int main(int argc, char* argv[])

--- a/benchmarks/expand3.cpp
+++ b/benchmarks/expand3.cpp
@@ -23,7 +23,6 @@ using SymEngine::Integer;
 using SymEngine::integer;
 using SymEngine::multinomial_coefficients;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 
 int main(int argc, char* argv[])

--- a/benchmarks/matrix_add1.cpp
+++ b/benchmarks/matrix_add1.cpp
@@ -11,7 +11,6 @@
 using SymEngine::Basic;
 using SymEngine::Integer;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::integer;
 using SymEngine::DenseMatrix;
 

--- a/benchmarks/matrix_add2.cpp
+++ b/benchmarks/matrix_add2.cpp
@@ -9,7 +9,6 @@
 
 using SymEngine::Basic;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::DenseMatrix;
 using SymEngine::symbol;
 

--- a/benchmarks/matrix_mul1.cpp
+++ b/benchmarks/matrix_mul1.cpp
@@ -10,7 +10,6 @@
 using SymEngine::Basic;
 using SymEngine::Integer;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::integer;
 using SymEngine::DenseMatrix;
 

--- a/benchmarks/matrix_mul2.cpp
+++ b/benchmarks/matrix_mul2.cpp
@@ -9,7 +9,6 @@
 
 using SymEngine::Basic;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::DenseMatrix;
 using SymEngine::symbol;
 

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -81,62 +81,58 @@ make
 echo "Running make install:"
 make install
 
-if [[ "${WITH_SYMENGINE_RCP}" == "no" ]]; then
-    echo "SymEngine successfully built with Teuchos::RCP. No tests being run."
-else
-    echo "Running tests in build directory:"
-    # C++
-    ctest --output-on-failure
-    # Python
-    if [[ "${WITH_PYTHON}" == "yes" ]]; then
-        cd symengine/python
-        nosetests -v
-        cd ../../
-    fi
-    # Ruby
-    if [[ "${WITH_RUBY}" == "yes" ]]; then
-        RUBY_GEM_DIR="$SOURCE_DIR/symengine/ruby"
-        echo "Installing dependent gems"
-        cd $RUBY_GEM_DIR
-        bundle install
-        echo "Running RSpec tests for Ruby extension in $RUBY_GEM_DIR"
-        bundle exec rspec
-        cd $SOURCE_DIR
-    fi
+echo "Running tests in build directory:"
+# C++
+ctest --output-on-failure
+# Python
+if [[ "${WITH_PYTHON}" == "yes" ]]; then
+    cd symengine/python
+    nosetests -v
+    cd ../../
+fi
+# Ruby
+if [[ "${WITH_RUBY}" == "yes" ]]; then
+    RUBY_GEM_DIR="$SOURCE_DIR/symengine/ruby"
+    echo "Installing dependent gems"
+    cd $RUBY_GEM_DIR
+    bundle install
+    echo "Running RSpec tests for Ruby extension in $RUBY_GEM_DIR"
+    bundle exec rspec
+    cd $SOURCE_DIR
+fi
 
-    echo "Running tests using installed SymEngine:"
-    # C++
-    cd $SOURCE_DIR/symengine/tests/basic/
-    extra_libs=""
-    if [[ "${WITH_BFD}" != "" ]]; then
-        extra_libs="$extra_libs -lbfd"
-    fi
-    if [[ "${WITH_ECM}" != "" ]]; then
-        extra_libs="$extra_libs -lecm"
-    fi
-    if [[ "${WITH_PRIMESIEVE}" != "" ]]; then
-        extra_libs="$extra_libs -lprimesieve"
-    fi
-    if [[ "${WITH_ARB}" != "" ]]; then
-        extra_libs="$extra_libs -larb -lflint"
-    fi
-    if [[ "${WITH_MPC}" != "" ]]; then
-        extra_libs="$extra_libs -lmpc"
-    fi
-    if [[ "${WITH_MPFR}" == "yes" ]] || [[ "${WITH_MPC}" == "yes" ]] || [[ "${WITH_ARB}" == "yes" ]]; then
-        extra_libs="$extra_libs -lmpfr"
-    fi
-    ${CXX} -std=c++0x -I$our_install_dir/include/ -L$our_install_dir/lib test_basic.cpp -lsymengine -lteuchos $extra_libs -lgmpxx -lgmp
-    export LD_LIBRARY_PATH=$our_install_dir/lib:$LD_LIBRARY_PATH
-    ./a.out
-    # Python
-    if [[ "${WITH_PYTHON}" == "yes" ]]; then
-        mkdir -p empty
-        cd empty
-        cat << EOF | python
+echo "Running tests using installed SymEngine:"
+# C++
+cd $SOURCE_DIR/symengine/tests/basic/
+extra_libs=""
+if [[ "${WITH_BFD}" != "" ]]; then
+    extra_libs="$extra_libs -lbfd"
+fi
+if [[ "${WITH_ECM}" != "" ]]; then
+    extra_libs="$extra_libs -lecm"
+fi
+if [[ "${WITH_PRIMESIEVE}" != "" ]]; then
+    extra_libs="$extra_libs -lprimesieve"
+fi
+if [[ "${WITH_ARB}" != "" ]]; then
+    extra_libs="$extra_libs -larb -lflint"
+fi
+if [[ "${WITH_MPC}" != "" ]]; then
+    extra_libs="$extra_libs -lmpc"
+fi
+if [[ "${WITH_MPFR}" == "yes" ]] || [[ "${WITH_MPC}" == "yes" ]] || [[ "${WITH_ARB}" == "yes" ]]; then
+    extra_libs="$extra_libs -lmpfr"
+fi
+${CXX} -std=c++0x -I$our_install_dir/include/ -L$our_install_dir/lib test_basic.cpp -lsymengine -lteuchos $extra_libs -lgmpxx -lgmp
+export LD_LIBRARY_PATH=$our_install_dir/lib:$LD_LIBRARY_PATH
+./a.out
+# Python
+if [[ "${WITH_PYTHON}" == "yes" ]]; then
+    mkdir -p empty
+    cd empty
+    cat << EOF | python
 import symengine
 if not symengine.test():
     raise Exception('Tests failed')
 EOF
-    fi
 fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -123,7 +123,7 @@ fi
 if [[ "${WITH_MPFR}" == "yes" ]] || [[ "${WITH_MPC}" == "yes" ]] || [[ "${WITH_ARB}" == "yes" ]]; then
     extra_libs="$extra_libs -lmpfr"
 fi
-${CXX} -std=c++0x -I$our_install_dir/include/ -I$SOURCE_DIR/symengine/teuchos -L$our_install_dir/lib test_basic.cpp -lsymengine -lteuchos $extra_libs -lgmpxx -lgmp
+${CXX} -std=c++0x -I$our_install_dir/include/ -I$SOURCE_DIR/symengine/teuchos -I$SOURCE_DIR/build/symengine/teuchos -L$our_install_dir/lib test_basic.cpp -lsymengine -lteuchos $extra_libs -lgmpxx -lgmp
 export LD_LIBRARY_PATH=$our_install_dir/lib:$LD_LIBRARY_PATH
 ./a.out
 # Python

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -123,7 +123,7 @@ fi
 if [[ "${WITH_MPFR}" == "yes" ]] || [[ "${WITH_MPC}" == "yes" ]] || [[ "${WITH_ARB}" == "yes" ]]; then
     extra_libs="$extra_libs -lmpfr"
 fi
-${CXX} -std=c++0x -I$our_install_dir/include/ -L$our_install_dir/lib test_basic.cpp -lsymengine -lteuchos $extra_libs -lgmpxx -lgmp
+${CXX} -std=c++0x -I$our_install_dir/include/ -I$SOURCE_DIR/symengine/teuchos -L$our_install_dir/lib test_basic.cpp -lsymengine -lteuchos $extra_libs -lgmpxx -lgmp
 export LD_LIBRARY_PATH=$our_install_dir/lib:$LD_LIBRARY_PATH
 ./a.out
 # Python

--- a/doc/design.md
+++ b/doc/design.md
@@ -52,8 +52,8 @@ the code works with both.
 
 Ideally, we would like to be able to do:
 
-    RCP<Basic> x  = rcp(new Symbol("x"));
-    RCP<Basic> y  = rcp(new Symbol("y"));
+    RCP<Basic> x  = make_rcp<Symbol>("x");
+    RCP<Basic> y  = make_rcp<Symbol>("y");
     RCP<Basic> r = (x + y) + (y + x);
     std::cout << r << std::endl;
 

--- a/doc/style_guide.md
+++ b/doc/style_guide.md
@@ -14,9 +14,15 @@ Use 4 spaces. Format ``if`` as follows:
 
 ## Pointers
 
-Never use raw C++ pointers. Always use the smart pointers provided by `symengine_rcp.h`
-(depending on WITH_SYMENGINE_RCP, those are either Teuchos::RCP, or our own,
-faster implementation).
+Never use raw C++ pointers and never use the raw `new` and `delete`. Always use
+the smart pointers provided by `symengine_rcp.h` (depending on
+WITH_SYMENGINE_RCP, those are either Teuchos::RCP, or our own, faster
+implementation), i.e. `Ptr` and `RCP` (and do not use the `.get()` method, only
+the `.ptr()` method). In Debug mode, the pointers are 100% safe, i.e. no matter
+how you use them the code will not segfault, but instead raise a nice exception
+if a pointer becomes dangling or null. In Release mode, the `Ptr` is as fast as
+a raw pointer and `RCP` is a lot faster, but no checks are done (so the code
+can segfault).
 
 ### Declaration
 
@@ -25,7 +31,7 @@ In the `.cpp` files you can declare:
     using SymEngine::RCP;
     using SymEngine::Ptr;
     using SymEngine::outArg;
-    using SymEngine::rcp;
+    using SymEngine::make_rcp;
     using SymEngine::rcp_dynamic_cast;
     
 and then just use `RCP` or `Ptr`.
@@ -36,15 +42,15 @@ In the `.h` header files use the full name like `SymEngine::RCP` or `SymEngine::
 
 Initialize as follows:
 
-    RCP<Basic> x  = rcp(new Symbol("x"));
+    RCP<Basic> x  = make_rcp<Symbol>("x");
 
-This is the only place where you use the naked ``new``. In fact, you should always be
-using the factory functions if they are available, e.g. in this case `symbol()`
-as follows:
+Never call the naked `new`, nor use the naked `rcp`. If available, use the
+factory functions, e.g. in this case `symbol()` as follows:
 
     RCP<Basic> x  = symbol("x");
 
-This does the same thing, but it's easier to use.
+This does the same thing (internally it calls `make_rcp`), but it is easier to
+use.
 
 ### Freeing
 
@@ -83,7 +89,7 @@ Declare functions with two input arguments (and one return value) as follows:
             const RCP<const Basic> &b)
     {
         ...
-        return rcp(new Integer(1));
+        return make_rcp<const Integer>(1);
     }
 
 Functions with one input and two output arguments are declared:
@@ -93,7 +99,7 @@ Functions with one input and two output arguments are declared:
         const Ptr<RCP<const Basic>> &term)
     {
         ...
-        *coef = rcp(new Integer(1));
+        *coef = make_rcp<const Integer>(1);
         *term = self
         ...
     }

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,24 +10,22 @@ env:
   ## Out of tree builds (default):
   # Debug build
   - BUILD_TYPE="Debug"
-  # Debug build (with BFD and SYMENGINE_ASSERT)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with Python 2.7
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
-  # Debug build (with BFD and SYMENGINE_ASSERT and SYMENGINE_THREAD_SAFE)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with ECM
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_ECM="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with PRIMESIEVE
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PRIMESIEVE="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with Arb
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_ARB="yes"
-  # Debug build (with BFD and SYMENGINE_ASSERT) with MPC
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_MPC="yes"
-  # Debug build shared lib (with BFD and SYMENGINE_ASSERT)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" BUILD_SHARED_LIBS="yes"
-  # Debug build with Teuchos::RCP (just to test that it compiles)
-  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_RCP="no"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with Python 2.7
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+  # Debug build (with BFD and SYMENGINE_ASSERT and SYMENGINE_THREAD_SAFE and Teuchos::RCP)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_SYMENGINE_THREAD_SAFE="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with ECM
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_ECM="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with PRIMESIEVE
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PRIMESIEVE="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with Arb
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_ARB="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT and Teuchos::RCP) with MPC
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_MPC="yes"
+  # Debug build shared lib (with BFD and SYMENGINE_ASSERT and Teuchos::RCP)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" BUILD_SHARED_LIBS="yes"
   # Release build (with BFD)
   - WITH_BFD="yes"
 
@@ -35,7 +33,7 @@ env:
   # Debug build without Python:
   - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes"
   # Debug build with Python 2.7:
-  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_SYMENGINE_ASSERT="yes" PYTHON_VERSION="2.7"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" PYTHON_VERSION="2.7"
   # Release build with Python 2.7:
   - TEST_IN_TREE="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
   # Release build shared lib with Python 2.7:

--- a/symengine/basic-inl.h
+++ b/symengine/basic-inl.h
@@ -9,11 +9,26 @@ inline std::size_t Basic::hash() const
         hash_ = __hash__();
     return hash_;
 }
+
 //! \return true if not equal    
 inline bool Basic::__neq__(const Basic &o) const
 {
     return !(this->__eq__(o));
 }
+
+inline RCP<const Basic> Basic::get_rcp() const {
+    return get_rcp_cast<const Basic>();
+}
+
+template <class T>
+inline RCP<T> Basic::get_rcp_cast() const {
+#if defined(WITH_SYMENGINE_RCP)
+    return rcp(static_cast<T*>(this));
+#else
+    return rcp_static_cast<T>(weak_self_ptr_.create_strong());
+#endif
+}
+
 //! \return true if  `a` equal `b`
 inline bool eq(const RCP<const Basic> &a, const RCP<const Basic> &b)
 {

--- a/symengine/basic-inl.h
+++ b/symengine/basic-inl.h
@@ -38,18 +38,6 @@ inline bool is_a_sub(const Basic &b)
     return dynamic_cast<const T *>(&b) != nullptr;
 }
 
-template<typename T, typename ...Args>
-inline RCP<T> make_rcp( Args&& ...args )
-{
-#if defined(WITH_SYMENGINE_RCP)
-    return rcp( new T( std::forward<Args>(args)... ) );
-#else
-    RCP<T> p = rcp( new T( std::forward<Args>(args)... ) );
-    p->weak_self_ptr_ = p.create_weak();
-    return p;
-#endif
-}
-
 } // SymEngine
 
 // global namespace functions

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -135,18 +135,12 @@ public:
     //! Assignment operator in continuation with above
     Basic& operator=(Basic&&) = delete;
 
-    RCP<const Basic> get_rcp() const {
-        return get_rcp_cast<const Basic>();
-    }
+    //! Get RCP<const Basic> pointer to self
+    inline RCP<const Basic> get_rcp() const;
 
+    //! Get RCP<T> pointer to self (it will cast the pointer to T)
     template <class T>
-    RCP<T> get_rcp_cast() const {
-#if defined(WITH_SYMENGINE_RCP)
-        return rcp(static_cast<T*>(this));
-#else
-        return rcp_static_cast<T>(weak_self_ptr_.create_strong());
-#endif
-    }
+    inline RCP<T> get_rcp_cast() const;
 
     /*!  Implements the hash of the given SymEngine class.
          Use `std::hash` to get the hash. Example:

--- a/symengine/basic.h
+++ b/symengine/basic.h
@@ -255,9 +255,6 @@ bool is_a_sub(const Basic &b);
 //! Expands `self`
 RCP<const Basic> expand(const RCP<const Basic> &self);
 
-template<typename T, typename ...Args>
-inline RCP<T> make_rcp( Args&& ...args );
-
 } // SymEngine
 
 /*! This `<<` overloaded function simply calls `p.__str__`, so it allows any Basic

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -31,15 +31,12 @@ extern "C" {
 
 void basic_init(basic s)
 {
-#if defined(WITH_SYMENGINE_RCP)
     // These checks only happen at compile time.
     // Check that 'basic' has the correct size:
     static_assert(sizeof(RCP<const Basic>) == sizeof(basic), "Size of 'basic' is not correct");
     // Check that 'basic' has the correct alignment:
     static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "Alignment of 'basic' is not correct");
-#else
-    throw std::runtime_error("Teuchos::RCP is not compatible with the C wrappers");
-#endif
+
     // No allocation is being done, but the constructor of RCP is called and
     // the instance is initialized at the memory address 's'. The above checks
     // make sure that 's' has the correct size and alignment, which is

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -14,7 +14,6 @@
 
 using SymEngine::Basic;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::zero;
 using SymEngine::Symbol;
 using SymEngine::Rational;

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -11,17 +11,24 @@ extern "C" {
 // must have the same alignment (because we allocate RCP<const Basic> into the
 // memory occupied by this struct in cwrapper.cpp). We cannot use C++ in this
 // file, so we need to use C tools to arrive at the correct size and alignment.
-// The size of the RCP object on most platforms should be just the size of the
-// 'T *ptr_' pointer that it contains (as there is no virtual function table)
-// and the alignment should also be of a pointer. So we just put 'void *data'
-// as the only member of the struct, that should have the correct size and
-// alignment.  However, this is checked at compile time in cwrapper.cpp, so if
-// the size or alignment is different on some platform, the compilation will
-// fail --- in that case one needs to modify the contents of this struct to
-// adjust its size and/or alignment.
+// The size of the RCP object on most platforms (with WITH_SYMENGINE_RCP on)
+// should be just the size of the 'T *ptr_' pointer that it contains (as there
+// is no virtual function table) and the alignment should also be of a pointer.
+// So we just put 'void *data' as the only member of the struct, that should
+// have the correct size and alignment. With WITH_SYMENGINE_RCP off (i.e. using
+// Teuchos::RCP), we have to add additional members into the structure.
+//
+// However, this is checked at compile time in cwrapper.cpp, so if the size or
+// alignment is different on some platform, the compilation will fail --- in
+// that case one needs to modify the contents of this struct to adjust its size
+// and/or alignment.
 typedef struct
 {
     void *data;
+#if !defined(WITH_SYMENGINE_RCP)
+    void *teuchos_handle;
+    int teuchos_strength;
+#endif
 } basic_struct;
 
 //! 'basic' is internally implemented as a size 1 array of the type

--- a/symengine/dict.cpp
+++ b/symengine/dict.cpp
@@ -99,6 +99,11 @@ std::ostream& operator<<(std::ostream& out, const SymEngine::vec_basic& d)
     return print_vec_rcp(out, d);
 }
 
+std::ostream& operator<<(std::ostream& out, const SymEngine::set_basic& d)
+{
+    return print_vec_rcp(out, d);
+}
+
 
 namespace SymEngine {
 

--- a/symengine/dict.h
+++ b/symengine/dict.h
@@ -108,6 +108,7 @@ std::ostream& operator<<(std::ostream& out, const SymEngine::map_basic_num& d);
 std::ostream& operator<<(std::ostream& out, const SymEngine::map_basic_basic& d);
 std::ostream& operator<<(std::ostream& out, const SymEngine::umap_basic_basic& d);
 std::ostream& operator<<(std::ostream& out, const SymEngine::vec_basic& d);
+std::ostream& operator<<(std::ostream& out, const SymEngine::set_basic& d);
 
 #endif
 

--- a/symengine/python/symengine/lib/symengine.pxd
+++ b/symengine/python/symengine/lib/symengine.pxd
@@ -173,14 +173,16 @@ cdef extern from "<symengine/pow.h>" namespace "SymEngine":
 
 cdef extern from "<symengine/basic.h>" namespace "SymEngine":
     # We need to specialize these for our classes:
-    RCP[const Basic] rcp(Symbol *p) nogil
-    RCP[const Basic] rcp(Constant *p) nogil
-    RCP[const Basic] rcp(Integer *p) nogil
-    RCP[const Basic] rcp(Subs *p) nogil
-    RCP[const Basic] rcp(Derivative *p) nogil
-    RCP[const Basic] rcp(FunctionWrapper *p) nogil
-    RCP[const Basic] rcp(RealDouble *p) nogil
-    RCP[const Basic] rcp(ComplexDouble *p) nogil
+    RCP[const Basic] make_rcp_Symbol "SymEngine::make_rcp<const SymEngine::Symbol>"(string name) nogil
+    RCP[const Basic] make_rcp_Constant "SymEngine::make_rcp<const SymEngine::Constant>"(string name) nogil
+    RCP[const Basic] make_rcp_Integer "SymEngine::make_rcp<const SymEngine::Integer>"(int i) nogil
+    RCP[const Basic] make_rcp_Integer "SymEngine::make_rcp<const SymEngine::Integer>"(mpz_class i) nogil
+    RCP[const Basic] make_rcp_Subs "SymEngine::make_rcp<const SymEngine::Subs>"(const RCP[const Basic] &arg, const map_basic_basic &x) nogil
+    RCP[const Basic] make_rcp_Derivative "SymEngine::make_rcp<const SymEngine::Derivative>"(const RCP[const Basic] &arg, const vec_basic &x) nogil
+    RCP[const Basic] make_rcp_FunctionWrapper "SymEngine::make_rcp<const SymEngine::FunctionWrapper>"(void* obj, string name, string hash_, const vec_basic &arg, \
+            void (*dec_ref)(void *), int (*comp)(void *, void *)) nogil
+    RCP[const Basic] make_rcp_RealDouble "SymEngine::make_rcp<const SymEngine::RealDouble>"(double x) nogil
+    RCP[const Basic] make_rcp_ComplexDouble "SymEngine::make_rcp<const SymEngine::ComplexDouble>"(double complex x) nogil
 
 cdef extern from "<symengine/functions.h>" namespace "SymEngine":
     cdef RCP[const Basic] sin(RCP[const Basic] &arg) nogil except+

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -1,6 +1,6 @@
 from cython.operator cimport dereference as deref, preincrement as inc
 cimport symengine
-from symengine cimport rcp, RCP, set
+from symengine cimport RCP, set
 from libcpp cimport bool
 from libcpp.string cimport string
 from cpython cimport PyObject, Py_XINCREF, Py_XDECREF, \
@@ -252,7 +252,7 @@ cdef class Symbol(Basic):
     def __cinit__(self, name = None):
         if name is None:
             return
-        self.thisptr = rcp(new symengine.Symbol(name.encode("utf-8")))
+        self.thisptr = symengine.make_rcp_Symbol(name.encode("utf-8"))
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -267,7 +267,7 @@ cdef class Constant(Basic):
     def __cinit__(self, name = None):
         if name is None:
             return
-        self.thisptr = rcp(new symengine.Constant(name.encode("utf-8")))
+        self.thisptr = symengine.make_rcp_Constant(name.encode("utf-8"))
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -303,9 +303,9 @@ cdef class Integer(Number):
             i__ = symengine.mpz_class(tmp, 10)
         # Note: all other exceptions are left intact
         if int_ok:
-            self.thisptr = rcp(new symengine.Integer(i_))
+            self.thisptr = symengine.make_rcp_Integer(i_)
         else:
-            self.thisptr = rcp(new symengine.Integer(i__))
+            self.thisptr = symengine.make_rcp_Integer(i__)
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -361,7 +361,7 @@ cdef class RealDouble(Number):
         if i is None:
             return
         cdef double i_ = i
-        self.thisptr = rcp(new symengine.RealDouble(i_))
+        self.thisptr = symengine.make_rcp_RealDouble(i_)
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -376,7 +376,7 @@ cdef class ComplexDouble(Number):
         if i is None:
             return
         cdef double complex i_ = i
-        self.thisptr = rcp(new symengine.ComplexDouble(i_))
+        self.thisptr = symengine.make_rcp_ComplexDouble(i_)
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -522,7 +522,7 @@ cdef class FunctionWrapper(FunctionSymbol):
             arg_ = sympify(arg)
             v.push_back(arg_.thisptr)
         SymPy_XINCREF(ptr)
-        self.thisptr = rcp(new symengine.FunctionWrapper(ptr, name, hash_, v, &SymPy_XDECREF, &SymPy_CMP))
+        self.thisptr = symengine.make_rcp_FunctionWrapper(ptr, name, hash_, v, &SymPy_XDECREF, &SymPy_CMP)
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -556,7 +556,7 @@ cdef class Derivative(Basic):
         for s in symbols:
             s_ = sympify(s, True)
             vec.push_back(s_.thisptr)
-        self.thisptr = rcp(new symengine.Derivative(<const RCP[const symengine.Basic]>expr_.thisptr, vec))
+        self.thisptr = symengine.make_rcp_Derivative(<const RCP[const symengine.Basic]>expr_.thisptr, vec)
 
     def __dealloc__(self):
         self.thisptr.reset()
@@ -585,7 +585,7 @@ cdef class Subs(Basic):
             v_ = sympify(v, True)
             p_ = sympify(p, True)
             m[v_.thisptr] = p_.thisptr
-        self.thisptr = rcp(new symengine.Subs(<const RCP[const symengine.Basic]>expr_.thisptr, m))
+        self.thisptr = symengine.make_rcp_Subs(<const RCP[const symengine.Basic]>expr_.thisptr, m)
 
     def __dealloc__(self):
         self.thisptr.reset()

--- a/symengine/rational.h
+++ b/symengine/rational.h
@@ -229,7 +229,7 @@ public:
     virtual void accept(Visitor &v) const;
 };
 
-//! returns the `num` and `den` of rational `rat` as `rcp Integer`
+//! returns the `num` and `den` of rational `rat` as `RCP<const Integer>`
 void get_num_den(const RCP<const Rational> &rat,
         const Ptr<RCP<const Integer>> &num,
         const Ptr<RCP<const Integer>> &den);

--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -196,6 +196,20 @@ using Teuchos::print_stack_on_segfault;
 
 #endif
 
+
+template<typename T, typename ...Args>
+inline RCP<T> make_rcp( Args&& ...args )
+{
+#if defined(WITH_SYMENGINE_RCP)
+    return rcp( new T( std::forward<Args>(args)... ) );
+#else
+    RCP<T> p = rcp( new T( std::forward<Args>(args)... ) );
+    p->weak_self_ptr_ = p.create_weak();
+    return p;
+#endif
+}
+
+
 } // SymEngine
 
 

--- a/symengine/tests/basic/test_arit.cpp
+++ b/symengine/tests/basic/test_arit.cpp
@@ -30,7 +30,6 @@ using SymEngine::one;
 using SymEngine::zero;
 using SymEngine::sin;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::sqrt;
 using SymEngine::pow;
 using SymEngine::add;

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -657,6 +657,11 @@ void test_free_symbols()
     s = free_symbols(*r1);
     assert(s.size() == 1);
     assert(s.count(x) == 1);
+
+    r1 = mul(x, integer(2));
+    s = free_symbols(*r1);
+    assert(s.size() == 1);
+    assert(s.count(x) == 1);
 }
 
 int main(int argc, char* argv[])

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -46,7 +46,6 @@ using SymEngine::function_symbol;
 using SymEngine::Derivative;
 using SymEngine::pi;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::make_rcp;
 using SymEngine::print_stack_on_segfault;
 using SymEngine::sqrt;

--- a/symengine/tests/basic/test_poly.cpp
+++ b/symengine/tests/basic/test_poly.cpp
@@ -29,7 +29,6 @@ using SymEngine::monomial_mul;
 using SymEngine::poly_mul;
 using SymEngine::umap_vec_mpz;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 using SymEngine::print_stack_on_segfault;
 

--- a/symengine/tests/basic/test_subs.cpp
+++ b/symengine/tests/basic/test_subs.cpp
@@ -26,7 +26,6 @@ using SymEngine::one;
 using SymEngine::zero;
 using SymEngine::sin;
 using SymEngine::RCP;
-using SymEngine::rcp;
 using SymEngine::rcp_dynamic_cast;
 using SymEngine::map_basic_basic;
 using SymEngine::print_stack_on_segfault;

--- a/symengine/tests/printing/test_printing.cpp
+++ b/symengine/tests/printing/test_printing.cpp
@@ -28,7 +28,6 @@ using SymEngine::add;
 using SymEngine::Symbol;
 using SymEngine::Integer;
 using SymEngine::DenseMatrix;
-using SymEngine::rcp;
 using SymEngine::Subs;
 using SymEngine::Derivative;
 using SymEngine::function_symbol;

--- a/symengine/tests/rcp/test_rcp.cpp
+++ b/symengine/tests/rcp/test_rcp.cpp
@@ -3,14 +3,18 @@
 #include <symengine/symengine_rcp.h>
 
 using SymEngine::RCP;
-using SymEngine::rcp;
+using SymEngine::make_rcp;
 using SymEngine::Ptr;
 using SymEngine::null;
 
 class Mesh {
 public:
+#if defined(WITH_SYMENGINE_RCP)
     mutable unsigned int refcount_;
     Mesh() : refcount_(0) {}
+#else
+    mutable RCP<const Mesh> weak_self_ptr_;
+#endif
 
     int x, y;
 };
@@ -18,10 +22,12 @@ public:
 int main(int argc, char* argv[])
 {
 
-    RCP<Mesh> m = rcp(new Mesh());
+    RCP<Mesh> m = make_rcp<Mesh>();
     Ptr<Mesh> p = m.ptr();
     if (m == null) return 1;
+#if defined(WITH_SYMENGINE_RCP)
     if (p->refcount_ != 1) return 1;
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Fixes #450

Now the standard recommendation for development is to use both `-DWITH_SYMENGINE_ASSERT=yes` and `-DWITH_SYMENGINE_RCP=no`, then the code should never segfault or have undefined behavior. The flag `CMAKE_BUILD_TYPE` (`Release` or `Debug`) is only used for compiler optimization options --- for bigger calculations that behave weird, one can keep the `Release` build type, but still turn on the `-DWITH_SYMENGINE_ASSERT=yes` and `-DWITH_SYMENGINE_RCP=no` options, which will make the code 100% safe. I updated the README.