### PR TITLE
Fix typo in compiler choice CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ irrespective of the user input for `WITH_SYMENGINE_THREAD_SAFE`.
 `CMake` prints the value of its options at the end of the run.
 If you want to use a different compiler, do:
 
-    CXX=clang cmake .
+    CC=clang CXX=clang++ cmake .
 
 and check that CMake picked it up.
 


### PR DESCRIPTION
I think it should be either
`CXX=clang++ cmake .` or `CC=clang cmake .`
Because `CXX=clang cmake .` doesn't work on my machine.
Close this if I am wrong.
@certik @isuruf 