### PR TITLE
Make SYMENGINE_ASSERT use custom assert instead of assert()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ if (WITH_PIRANHA)
     set(WITH_BOOST yes)
     set(WITH_PTHREAD yes)
     set(WITH_MPFR yes)
+    set(CMAKE_CXX_FLAGS_RELEASE
+        "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 
     find_package(Piranha REQUIRED)
     include_directories(${PIRANHA_INCLUDE_DIRS})

--- a/symengine/symengine_assert.h
+++ b/symengine/symengine_assert.h
@@ -1,10 +1,21 @@
 #ifndef SYMENGINE_ASSERT_H
 #define SYMENGINE_ASSERT_H
 
-
+// SYMENGINE_ASSERT uses internal functions to perform as assert
+// so that there is no effect with NDEBUG
 #if !defined(SYMENGINE_ASSERT)
 #if defined(WITH_SYMENGINE_ASSERT)
-#define SYMENGINE_ASSERT(cond) assert(cond);
+#define stringize(s) #s
+#define XSTR(s) stringize(s)
+#define SYMENGINE_ASSERT(cond) \
+{ \
+if (0 == (cond)) { \
+std::cerr << "SYMENGINE_ASSERT failed: " << __FILE__ << \
+	"\nfunction " << __func__ <<  "(), line number " << __LINE__ << \
+	" at \n" << XSTR(cond) << "\n"; \
+abort(); \
+} \
+}
 #else
 #define SYMENGINE_ASSERT(cond)
 #endif

--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -1,6 +1,7 @@
 #ifndef SYMENGINE_RCP_H
 #define SYMENGINE_RCP_H
 
+#include <iostream>
 #include <cstddef>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
En route to fixing https://github.com/sympy/symengine/issues/482
/cc @certik @isuruf 