### PR TITLE
Use mpzaddmul for poly_mul

### DIFF
--- a/symengine/rings.cpp
+++ b/symengine/rings.cpp
@@ -76,7 +76,7 @@ void poly_mul(const umap_vec_mpz &A, const umap_vec_mpz &B, umap_vec_mpz &C)
     for (auto &a: A) {
         for (auto &b: B) {
             monomial_mul(a.first, b.first, exp);
-            C[exp] += a.second*b.second;
+            mpz_addmul(C[exp].get_mpz_t(),a.second.get_mpz_t(),b.second.get_mpz_t());
         }
     }
     /*


### PR DESCRIPTION
Nice speedup obtained using FMA in `poly_mul`.
`expand2b` average falls from `95ms` to `60ms` on my machine.
As suggested by @bluescarni

PS: There may be other areas throughout SymEngine where we can use this, something to keep in mind.