### PR TITLE
Use BFD for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ matrix:
           - clang
           - libstdc++-4.8-dev
           - libgmp-dev
+          - binutils-dev
     - env: BUILD_TYPE="Release" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: linux
@@ -91,7 +92,7 @@ matrix:
           - clang
           - libstdc++-4.8-dev
           - libgmp-dev
-    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: osx
       addons:
@@ -102,6 +103,7 @@ matrix:
           - clang
           - libstdc++-4.8-dev
           - libgmp-dev
+          - binutils-dev
     - env: BUILD_TYPE="Release" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
           - clang
           - libstdc++-4.8-dev
           - libgmp-dev
-    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: osx
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     - libgmp-dev
     - libmpfr-dev
     - libmpc-dev
+    - binutils-dev
 env:
   ## All these variables are sent into the bin/test_travis.sh script. See this
   ## script to know how they are used. Most of them are just passed to cmake,
@@ -23,28 +24,30 @@ env:
   ## Out of tree builds (default):
   # Debug build
   - BUILD_TYPE="Debug"
-  # Debug build (with SYMENGINE_ASSERT and Teuchos::RCP)
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no"
-  # Debug build (with SYMENGINE_ASSERT and Teuchos::RCP) with Python 2.7
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
-  # Debug build (with SYMENGINE_ASSERT and SYMENGINE_THREAD_SAFE and Teuchos::RCP)
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_SYMENGINE_THREAD_SAFE="yes"
-  # Debug build (with SYMENGINE_ASSERT and Teuchos::RCP) with ECM
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_ECM="yes"
-  # Debug build (with SYMENGINE_ASSERT and Teuchos::RCP) with PRIMESIEVE
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PRIMESIEVE="yes"
-  # Debug build (with SYMENGINE_ASSERT and Teuchos::RCP) with Arb
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_ARB="yes"
-  # Debug build (with SYMENGINE_ASSERT and Teuchos::RCP) with MPC
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_MPC="yes"
-  # Debug build shared lib (with SYMENGINE_ASSERT and Teuchos::RCP)
-  - BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" BUILD_SHARED_LIBS="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT) with Python 2.7
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+  # Debug build (with BFD and SYMENGINE_ASSERT and SYMENGINE_THREAD_SAFE)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_THREAD_SAFE="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT) with ECM
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_ECM="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT) with PRIMESIEVE
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PRIMESIEVE="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT) with Arb
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_ARB="yes"
+  # Debug build (with BFD and SYMENGINE_ASSERT) with MPC
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_MPC="yes"
+  # Debug build shared lib (with BFD and SYMENGINE_ASSERT)
+  - BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" BUILD_SHARED_LIBS="yes"
+  # Release build (with BFD)
+  - WITH_BFD="yes"
 
   ## In-tree builds (we just check a few configurations to make sure they work):
   # Debug build without Python:
-  - BUILD_TYPE="Debug" TEST_IN_TREE="yes"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes"
   # Debug build with Python 2.7:
-  - BUILD_TYPE="Debug" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" PYTHON_VERSION="2.7"
+  - BUILD_TYPE="Debug" WITH_BFD="yes" TEST_IN_TREE="yes" WITH_PYTHON="yes" WITH_SYMENGINE_ASSERT="yes" PYTHON_VERSION="2.7"
   # Release build with Python 2.7:
   - TEST_IN_TREE="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
   # Release build shared lib with Python 2.7:
@@ -66,7 +69,7 @@ matrix:
     - compiler: clang
     - os: osx
   include:
-    - env: BUILD_TYPE="Debug" WITH_SYMENGINE_ASSERT="yes" WITH_SYMENGINE_RCP="no" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
+    - env: BUILD_TYPE="Debug" WITH_BFD="yes" WITH_SYMENGINE_ASSERT="yes" WITH_PYTHON="yes" PYTHON_VERSION="2.7"
       compiler: clang
       os: linux
       addons:


### PR DESCRIPTION
`binutils-dev` was added to apt-whitelist of Travis-CI , so now we can use it in Travis-CI
https://github.com/travis-ci/travis-ci/issues/4113