### PR TITLE
Improve python wrappers for matrix

### DIFF
--- a/symengine/python/symengine/lib/symengine.pxd
+++ b/symengine/python/symengine/lib/symengine.pxd
@@ -211,6 +211,7 @@ cdef extern from "<symengine/pow.h>" namespace "SymEngine":
     cdef RCP[const Basic] pow(RCP[const Basic] &a, RCP[const Basic] &b) nogil except+
     cdef RCP[const Basic] sqrt(RCP[const Basic] &x) nogil except+
     cdef RCP[const Basic] exp(RCP[const Basic] &x) nogil except+
+    cdef RCP[const Basic] log(RCP[const Basic] &x) nogil except+
     cdef RCP[const Basic] log(RCP[const Basic] &x, RCP[const Basic] &y) nogil except+
 
     cdef cppclass Pow(Basic):

--- a/symengine/python/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/python/symengine/lib/symengine_wrapper.pyx
@@ -956,17 +956,103 @@ cdef class DenseMatrix(MatrixBase):
     def __str__(self):
         return deref(self.thisptr).__str__().decode("utf-8")
 
+    def __add__(a, b):
+        a = sympify(a)
+        b = sympify(b)
+        if isinstance(a, MatrixBase):
+            if isinstance(b, MatrixBase):
+                return a.add_matrix(b)
+            else:
+                return a.add_scalar(b)
+        else:
+            return b.add_scalar(a)
+
+    def __mul__(a, b):
+        a = sympify(a)
+        b = sympify(b)
+        if isinstance(a, MatrixBase):
+            if isinstance(b, MatrixBase):
+                return a.mul_matrix(b)
+            else:
+                return a.mul_scalar(b)
+        else:
+            return b.mul_scalar(a)
+
+    def __getitem__(self, item):
+        s = [0, 0, 0, 0]
+        if isinstance(item, slice):
+            #TODO: support step in slice
+            s[0], s[1] = self._get_slice(item)
+            s[2], s[3] = 0, self.ncols() - 1
+        elif isinstance(item, int):
+            return self.get(item // self.nrows(), item % self.nrows())
+        elif isinstance(item, tuple):
+            if isinstance(item[0], int) and isinstance(item[1], int):
+                return self.get(item[0], item[1])
+            else:
+                for i in (0, 1):
+                    if isinstance(item[i], slice):
+                        s[2*i], s[2*i+1] = self._get_slice(item[i])
+                    else:
+                        s[2*i], s[2*i+1] = item[i], item[i]
+        else:
+            raise NotImplementedError
+        return self.submatrix(*s)
+
+    def __setitem__(self, key, value):
+        if isinstance(key, int):
+            self.set(key // self.nrows(), key % self.ncols(), value)
+            return
+        elif isinstance(key, tuple):
+            if isinstance(key[0], int) and isinstance(key[1], int):
+                self.set(key[0], key[1], value)
+                return
+            #TODO: support slicing
+        raise NotImplementedError
+
     def nrows(self):
         return deref(self.thisptr).nrows()
 
     def ncols(self):
         return deref(self.thisptr).ncols()
 
+    def _get_index(self, i, j):
+        nr = self.nrows()
+        nc = self.ncols()
+        if i < 0:
+            i += nr
+        if j < 0:
+            j += nc
+        if i < 0 or i >= nr:
+            raise IndexError
+        if j < 0 or j >= nc:
+            raise IndexError
+        return i, j
+
+    def _get_slice(self, slice):
+        i = slice.start
+        if i is None:
+            i = 0
+        if slice.stop is None:
+            j = self.ncols() - 1
+        else:
+            j = slice.stop - 1
+        return i, j
+
     def get(self, i, j):
+        i, j = self._get_index(i, j)
+        return self._get(i, j)
+
+    def _get(self, i, j):
         # No error checking is done
         return c2py(deref(self.thisptr).get(i, j))
 
     def set(self, i, j, e):
+        i, j = self._get_index(i, j)
+        return self._set(i, j, e)
+
+    def _set(self, i, j, e):
+        # No error checking is done
         cdef Basic e_ = sympify(e)
         if e_ is not None:
             deref(self.thisptr).set(i, j, <const RCP[const symengine.Basic] &>(e_.thisptr))
@@ -1022,6 +1108,11 @@ cdef class DenseMatrix(MatrixBase):
         return result
 
     def submatrix(self, r_i, r_j, c_i, c_j):
+        r_i, c_i = self._get_index(r_i, c_i)
+        r_j, c_j = self._get_index(r_j, c_j)
+        return self._submatrix(r_i, r_j, c_i, c_j)
+
+    def _submatrix(self, r_i, r_j, c_i, c_j):
         result = DenseMatrix(r_j - r_i + 1, c_j - c_i + 1)
         deref(self.thisptr).submatrix(r_i, r_j, c_i, c_j, deref(result.thisptr))
         return result
@@ -1236,8 +1327,10 @@ def exp(x):
     cdef Basic X = sympify(x)
     return c2py(symengine.exp(X.thisptr))
 
-def log(x, y = E):
+def log(x, y = None):
     cdef Basic X = sympify(x)
+    if y == None:
+        return c2py(symengine.log(X.thisptr))
     cdef Basic Y = sympify(y)
     return c2py(symengine.log(X.thisptr, Y.thisptr))
 

--- a/symengine/python/symengine/tests/test_matrices.py
+++ b/symengine/python/symengine/tests/test_matrices.py
@@ -19,6 +19,46 @@ def test_get():
     assert A.get(1, 0) == c
     assert A.get(1, 1) == d
 
+    assert A.get(-1, 0) == c
+    assert A.get(-1, -1) == d
+
+    raises(IndexError, lambda: A.get(2, 0))
+    raises(IndexError, lambda: A.get(0, 2))
+    raises(IndexError, lambda: A.get(-3, 0))
+
+def test_get_item():
+    A = DenseMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    assert A[5] == 6
+    assert A[-1] == 9
+    assert A[2, 2] == 9
+    assert A[-2, 2] == 6
+
+    assert A[1:2, 0] == DenseMatrix(1, 1, [4])
+    assert A[1:3, 0] == DenseMatrix(2, 1, [4, 7])
+    assert A[1:3, 0] == DenseMatrix(2, 1, [4, 7])
+    assert A[1:3, 1:] == DenseMatrix(2, 2, [5, 6, 8, 9])
+    assert A[1:3, :1] == DenseMatrix(2, 1, [4, 7])
+    assert A[1:] == DenseMatrix(2, 3, [4, 5, 6, 7, 8, 9])
+    assert A[-2:] == DenseMatrix(2, 3, [4, 5, 6, 7, 8, 9])
+
+    raises(IndexError, lambda: A[-10])
+    raises(IndexError, lambda: A[9])
+
+    raises(IndexError, lambda: A[1:3, 3])
+    raises(IndexError, lambda: A[1:3, -4])
+
+def test_set_item():
+    A = DenseMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    A[2] = 7
+    A[2, 2] = 8
+    A[-2] = 3
+    A[-2, -1] = 1
+
+    B = DenseMatrix(3, 3, [1, 2, 7, 4, 5, 1, 7, 3, 8])
+    assert A == B
+
 def test_set():
     i7 = Integer(7)
     y = Symbol("y")
@@ -75,6 +115,7 @@ def test_add_matrix():
     B = DenseMatrix(2, 2, [a - b, a + b, -a, b])
 
     assert A.add_matrix(B) == DenseMatrix(2, 2, [2*a, 2*a, 0, 2*b])
+    assert A + B == DenseMatrix(2, 2, [2*a, 2*a, 0, 2*b])
 
 def test_mul_matrix():
     A = DenseMatrix(2, 2, [1, 2, 3, 4])
@@ -90,6 +131,7 @@ def test_mul_matrix():
     B = DenseMatrix(2, 2, [1, 0, 1, 0])
 
     assert A.mul_matrix(B) == DenseMatrix(2, 2, [a + b, 0, c + d, 0])
+    assert A * B == DenseMatrix(2, 2, [a + b, 0, c + d, 0])
 
 def test_add_scalar():
     A = DenseMatrix(2, 2, [1, 2, 3, 4])
@@ -99,6 +141,8 @@ def test_add_scalar():
 
     i5 = Integer(5)
     assert A.add_scalar(i5) == DenseMatrix(2, 2, [6, 7, 8, 9])
+    assert A + 5 == DenseMatrix(2, 2, [6, 7, 8, 9])
+    assert 5 + A == DenseMatrix(2, 2, [6, 7, 8, 9])
 
 def test_mul_scalar():
     A = DenseMatrix(2, 2, [1, 2, 3, 4])
@@ -108,6 +152,8 @@ def test_mul_scalar():
 
     i5 = Integer(5)
     assert A.mul_scalar(i5) == DenseMatrix(2, 2, [5, 10, 15, 20])
+    assert A * 5 == DenseMatrix(2, 2, [5, 10, 15, 20])
+    assert 5 * A == DenseMatrix(2, 2, [5, 10, 15, 20])
 
 def test_transpose():
     A = DenseMatrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])


### PR DESCRIPTION
Add bounds checking for `get`, `set` and `submatrix`. Previous methods are renamed to `_get`, `_set`, `_submatrix` respectively.

Also operator overloads for *, + and indexing added.