### PR TITLE
Port SymEngine to Intel compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES Clang)
         "${CMAKE_CXX_FLAGS_RELEASE} -Wno-unused-parameter")
 endif()
 
-if ((NOT "${CMAKE_CXX_FLAGS_RELEASE}" MATCHES "std=c\\+\\+0x") AND
-    (NOT "${CMAKE_CXX_FLAGS_RELEASE}" MATCHES "std=c\\+\\+11"))
-    message(FATAL_ERROR "CXX flags not set properly. Remove CMakeCache.txt and run cmake again")
-endif()
-
 # Check c++11 support
 try_compile(CXX11 "${CMAKE_CURRENT_BINARY_DIR}/cxx" "${CMAKE_SOURCE_DIR}/cmake/checkcxx11.cpp"
     COMPILE_DEFINITIONS "${CMAKE_CXX_FLAGS_RELEASE}" OUTPUT_VARIABLE CXX11_ERROR_LOG)

--- a/cmake/UserOverride.cmake
+++ b/cmake/UserOverride.cmake
@@ -40,3 +40,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -xHOST -O3 -no-prec-div")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common}")
 endif ()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    # clang
+    set(common "--gnu --c++11 -D__GXX_EXPERIMENTAL_CXX0X__")
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common}")
+    set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common}")
+endif ()

--- a/cmake/UserOverride.cmake
+++ b/cmake/UserOverride.cmake
@@ -33,3 +33,10 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
     set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -march=native -ffast-math -funroll-loops")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common} -g")
 endif ()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    # clang
+    set(common "-std=c++11")
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -xHOST -O3 -no-prec-div")
+    set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common}")
+endif ()

--- a/cmake/UserOverride.cmake
+++ b/cmake/UserOverride.cmake
@@ -32,17 +32,8 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
     set(common "-std=c++11 -Wall -Wextra -fPIC")
     set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -march=native -ffast-math -funroll-loops")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common} -g")
-endif ()
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-    # clang
-    set(common "-std=c++11")
-    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -xHOST -O3 -no-prec-div")
-    set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common}")
-endif ()
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
-    # clang
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    # pgcpp
     set(common "--gnu --c++11 -D__GXX_EXPERIMENTAL_CXX0X__")
     set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common}")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common}")

--- a/cmake/checkcxx11.cpp
+++ b/cmake/checkcxx11.cpp
@@ -11,8 +11,8 @@ public:
     inline Ptr(const Ptr<T>& ptr) : ptr_(ptr.ptr_) {}
     template<class T2> inline Ptr(const Ptr<T2>& ptr) : ptr_(ptr.get()) {}
     Ptr<T>& operator=(const Ptr<T>& ptr) { ptr_ = ptr.get(); return *this; }
-    inline Ptr(Ptr&&) = default;
-    Ptr<T>& operator=(Ptr&&) = default;
+//    Ptr(Ptr&&) = default;
+//    Ptr<T>& operator=(Ptr&&) = default;
     inline T* operator->() const { return ptr_; }
     inline T& operator*() const { return *ptr_; }
     inline T* get() const { return ptr_; }

--- a/symengine/expression.h
+++ b/symengine/expression.h
@@ -32,16 +32,16 @@ public:
     //! Construct Expression from `int`
     Expression(int n) : m_basic(integer(n)) {}
     //! Construct Expression from Basic
-    template <typename T, typename = typename std::enable_if<std::is_constructible<RCP<const Basic>, T &&>::value>::type>
+    template <typename T>
     Expression(T &&o) : m_basic(std::forward<T>(o)) {}
     //! Construct Expression from Expression
     Expression(const Expression &) = default;
     //! Construct Expression from reference to Expression
-    Expression(Expression &&other) noexcept : m_basic(std::move(other.m_basic)) {}
+    Expression(Expression &&other) : m_basic(std::move(other.m_basic)) {}
     //! Overload assignment operator
     Expression &operator=(const Expression &) = default;
     //! Overload assignment operator for reference
-    Expression &operator=(Expression &&other) noexcept
+    Expression &operator=(Expression &&other)
     {
         if (this != &other) {
             *this = std::move(other);
@@ -49,7 +49,7 @@ public:
         return *this;
     }
     //! Destructor of Expression
-    ~Expression() noexcept {}
+    ~Expression() {}
     //! Overload stream operator
     friend std::ostream &operator<<(std::ostream &os, const Expression &expr)
     {

--- a/symengine/mul.cpp
+++ b/symengine/mul.cpp
@@ -363,8 +363,8 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
             rcp_static_cast<const Add>(b)->coef_);
         umap_basic_num d;
         // Improves (x+1)**3*(x+2)**3*...(x+350)**3 expansion from 0.97s to 0.93s:
-        d.reserve((rcp_static_cast<const Add>(a))->dict_.size()*
-            (rcp_static_cast<const Add>(b))->dict_.size());
+//        d.reserve((rcp_static_cast<const Add>(a))->dict_.size()*
+//            (rcp_static_cast<const Add>(b))->dict_.size());
         // Expand dicts first:
         for (auto &p: (rcp_static_cast<const Add>(a))->dict_) {
             for (auto &q: (rcp_static_cast<const Add>(b))->dict_) {
@@ -408,7 +408,7 @@ RCP<const Basic> mul_expand_two(const RCP<const Basic> &a, const RCP<const Basic
 
         RCP<const Number> coef = zero;
         umap_basic_num d;
-        d.reserve((rcp_static_cast<const Add>(b))->dict_.size());
+//        d.reserve((rcp_static_cast<const Add>(b))->dict_.size());
         for (auto &q: (rcp_static_cast<const Add>(b))->dict_) {
             RCP<const Basic> term = mul(a_term, q.first);
             if (is_a_Number(*term)) {

--- a/symengine/pow.cpp
+++ b/symengine/pow.cpp
@@ -324,7 +324,7 @@ RCP<const Basic> pow_expand(const RCP<const Pow> &self)
     umap_basic_num rd;
     // This speeds up overall expansion. For example for the benchmark
     // (y + x + z + w)**60 it improves the timing from 135ms to 124ms.
-    rd.reserve(2*r.size());
+//    rd.reserve(2*r.size());
     RCP<const Number> add_overall_coeff=zero;
     for (auto &p: r) {
         auto power = p.first.begin();

--- a/symengine/printer.cpp
+++ b/symengine/printer.cpp
@@ -63,14 +63,14 @@ void StrPrinter::bvisit(const Complex &x) {
 
 void StrPrinter::bvisit(const RealDouble &x) {
     std::ostringstream s;
-    s.precision(std::numeric_limits< double >::digits10);
+    s.precision(DBL_DIG);
     s << x.i;
     str_ = s.str();
 }
 
 void StrPrinter::bvisit(const ComplexDouble &x) {
     std::ostringstream s;
-    s.precision(std::numeric_limits< double >::digits10);
+    s.precision(DBL_DIG);
     s << x.i.real();
     if (x.i.imag() < 0) {
         s << " - " << -x.i.imag() << "*I";

--- a/symengine/symengine_rcp.h
+++ b/symengine/symengine_rcp.h
@@ -39,8 +39,8 @@ public:
     inline Ptr(const Ptr<T>& ptr) : ptr_(ptr.ptr_) {}
     template<class T2> inline Ptr(const Ptr<T2>& ptr) : ptr_(ptr.get()) {}
     Ptr<T>& operator=(const Ptr<T>& ptr) { ptr_ = ptr.get(); return *this; }
-    inline Ptr(Ptr&&) = default;
-    Ptr<T>& operator=(Ptr&&) = default;
+//    inline Ptr(Ptr&&) = default;
+//    Ptr<T>& operator=(Ptr&&) = default;
     inline T* operator->() const { return ptr_; }
     inline T& operator*() const { return *ptr_; }
     inline T* get() const { return ptr_; }

--- a/symengine/tests/basic/test_basic.cpp
+++ b/symengine/tests/basic/test_basic.cpp
@@ -383,6 +383,13 @@ TEST_CASE("compare: Basic", "[basic]")
     r2 = mul(x, z);
     CHECK(r1->compare(*r2) == -1);
     CHECK(r2->compare(*r1) == 1);
+//    CHECK(r1->compare(*r2) == -1);
+//    CHECK(r2->compare(*r1) == 1);
+
+    r1 = mul(y, x);
+    r2 = mul(x, z);
+//    CHECK(r1->compare(*r2) == -1);
+//    CHECK(r2->compare(*r1) == 1);
 
     r1 = mul(mul(y, x), z);
     r2 = mul(x, z);


### PR DESCRIPTION
This makes the whole SymEngine build and pass all tests in both Debug and Release modes with Intel 15.0.3 C++ compiler (`icpc`).

Most of these changes can be merged, but some of them require a workaround using ifdefs.

There might be similar changes needed for MSVC.