### PR TITLE
Make derivatives of abstract functions less tautological

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1617,9 +1617,33 @@ int Derivative::compare(const Basic &o) const
 RCP<const Basic> Derivative::diff(const RCP<const Symbol> &x) const
 {
     if (eq(*(arg_->diff(x)), *zero)) return zero;
+    unsigned i;
+    bool all_symbols = true;
+    bool directly_present = false;
     vec_basic t = x_;
-    t.push_back(x);
-    return Derivative::create(arg_, t);
+    vec_basic u = arg_->get_args();
+    for (i = 0; i < t.size(); i++) {
+        if (!is_a<Symbol>(*t[i])) {
+            all_symbols = false;
+            break;
+        }
+    }
+    for (i = 0; i < u.size(); i++) {
+        if (eq(*(u[i]->diff(x)), *one)) {
+            directly_present = true;
+            break;
+        }
+    }
+    if (!all_symbols || directly_present) {
+        t.push_back(x);
+        return Derivative::create(arg_, t);
+    } else {
+        RCP<const Basic> ret = arg_->diff(x);
+        for (i = 0; i < t.size(); i++) {
+            ret = ret->diff(rcp_static_cast<const Symbol>(t[i]));
+        }
+        return ret;
+    }
 }
 
 RCP<const Basic> Derivative::subs(const map_basic_basic &subs_dict) const

--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1808,7 +1808,15 @@ RCP<const Basic> Subs::subs(const map_basic_basic &subs_dict) const
     for (auto &s: dict_) {
         insert(m, s.first, s.second->subs(subs_dict));
     }
-    return make_rcp<const Subs>(arg_->subs(n), m);
+    RCP<const Basic> presub = arg_->subs(n);
+    if (neq(*presub, *(make_rcp<const Subs>(arg_, n)))) {
+        return make_rcp<const Subs>(presub, m);
+    } else {
+        for (auto &q: n) {
+            insert(m, q.first, q.second);
+        }
+        return make_rcp<const Subs>(arg_, m);
+    }
 }
 
 std::size_t HyperbolicFunction::__hash__() const

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -813,6 +813,7 @@ TEST_CASE("Subs: functions", "[functions]")
     RCP<const Symbol> y = symbol("y");
     RCP<const Symbol> z = symbol("z");
     RCP<const Symbol> _x = symbol("_x");
+    RCP<const Symbol> __x = symbol("__x");
     RCP<const Basic> r1, r2, r3, r4;
 
     // Test Subs::subs
@@ -844,9 +845,9 @@ TEST_CASE("Subs: functions", "[functions]")
     r2 = r1->diff(y);
     r3 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, _x}), 
                         {{_x, add(x, y)}});
-    r4 = Subs::create(Derivative::create(function_symbol("f", {add(y, y), _x}), {_x, y}), 
-                        {{_x, add(x, y)}});
-    r3 = add(r3, r4);
+    r4 = Subs::create(Derivative::create(function_symbol("f", {__x, _x}), {__x, _x}), 
+                        {{_x, add(x, y)}, {__x, add(y, y)}});
+    r3 = add(r3, add(r4, r4));
     REQUIRE(eq(*r2, *r3));
 }
 


### PR DESCRIPTION
Repeatedly differentiating composed function_symbol types should build up the Faa di Bruno formula (chain rule). However, the simplest implementation of Derivative::diff gives up too quickly by just adding symbols to differentiate by even when they are not directly present in the function. This modification gets the right answer when differentiating by symbols and falls back to the old method when it detects that non-symbols are present as well.