### PR TITLE
Rename basic_init() to basic_new_stack() and basic_free() to basic_free_stack()

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -46,7 +46,7 @@ struct CRCPBasic {
 static_assert(sizeof(CRCPBasic) == sizeof(CRCPBasic_C), "Size of 'basic' is not correct");
 static_assert(std::alignment_of<CRCPBasic>::value == std::alignment_of<CRCPBasic_C>::value, "Alignment of 'basic' is not correct");
 
-void basic_init(basic s)
+void basic_new_stack(basic s)
 {
     new(s) CRCPBasic();
 }

--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -51,7 +51,7 @@ void basic_new_stack(basic s)
     new(s) CRCPBasic();
 }
 
-void basic_free(basic s)
+void basic_free_stack(basic s)
 {
     s->m.~RCP();
 }

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -57,7 +57,7 @@ struct CRCPBasic_C
 //  CRCPBasic, which has the same size and alignment as RCP<const Basic> (see
 //  the above comment for details). That is then used by the user to allocate
 //  the memory needed for RCP<const Basic> on the stack. A 'basic' type should
-//  be initialized using basic_init(), before any function is called.
+//  be initialized using basic_new_stack(), before any function is called.
 //  Assignment should be done only by using basic_assign(). Before the variable
 //  goes out of scope, basic_free() must be called.
 //
@@ -72,7 +72,7 @@ typedef struct CRCPBasic_C basic_struct;
 typedef basic_struct basic[1];
 
 //! Initialize a new basic instance.
-void basic_init(basic s);
+void basic_new_stack(basic s);
 //! Assign value of b to a.
 void basic_assign(basic a, const basic b);
 //! Free the C++ class wrapped by s.

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -59,7 +59,7 @@ struct CRCPBasic_C
 //  the memory needed for RCP<const Basic> on the stack. A 'basic' type should
 //  be initialized using basic_new_stack(), before any function is called.
 //  Assignment should be done only by using basic_assign(). Before the variable
-//  goes out of scope, basic_free() must be called.
+//  goes out of scope, basic_free_stack() must be called.
 //
 //  For C, define a dummy struct with the right size, so that it can be
 //  allocated on the stack. For C++, the CRCPBasic is declared in cwrapper.cpp.
@@ -76,7 +76,7 @@ void basic_new_stack(basic s);
 //! Assign value of b to a.
 void basic_assign(basic a, const basic b);
 //! Free the C++ class wrapped by s.
-void basic_free(basic s);
+void basic_free_stack(basic s);
 
 // Use these two functions to allocate 'basic' on a heap:
 basic_struct* basic_new_heap();

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -71,16 +71,21 @@ typedef struct CRCPBasic_C basic_struct;
 
 typedef basic_struct basic[1];
 
-//! Initialize a new basic instance.
+//! Initialize a new basic instance. 's' is allocated on stack using the
+// 'basic' type, this function initializes an RCP<const Basic> on the stack
+// allocated variable. The 's' variable must be freed using basic_free_stack()
 void basic_new_stack(basic s);
-//! Assign value of b to a.
-void basic_assign(basic a, const basic b);
 //! Free the C++ class wrapped by s.
 void basic_free_stack(basic s);
 
-// Use these two functions to allocate 'basic' on a heap:
+// Use these two functions to allocate and free 'basic' on a heap. The pointer
+// can then be used in all the other methods below (i.e. the methods that
+// accept 'basic s' work no matter if 's' is stack or heap allocated).
 basic_struct* basic_new_heap();
 void basic_free_heap(basic_struct *s);
+
+//! Assign value of b to a.
+void basic_assign(basic a, const basic b);
 
 //Returns the typeID of the basic struct
 TypeID basic_get_type(const basic s);

--- a/symengine/ruby/ext/symengine/ruby_basic.c
+++ b/symengine/ruby/ext/symengine/ruby_basic.c
@@ -2,7 +2,7 @@
 
 void cbasic_free(void *ptr){
     basic_struct *basic_ptr = ptr;
-    basic_free(basic_ptr);
+    basic_free_stack(basic_ptr);
 }
 
 void cbasic_free_heap(void *ptr) {

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -61,10 +61,10 @@ void test_cwrapper() {
     SYMENGINE_C_ASSERT(mpz_get_ui(test) == 123);
 
     mpz_clear(test);
-    basic_free(e);
-    basic_free(x);
-    basic_free(y);
-    basic_free(z);
+    basic_free_stack(e);
+    basic_free_stack(x);
+    basic_free_stack(y);
+    basic_free_stack(z);
     basic_str_free(s);
 }
 
@@ -79,8 +79,8 @@ void test_basic() {
     // TODO: enable this once basic_eq() is implemented
     //SYMENGINE_C_ASSERT(basic_eq(x, y))
 
-    basic_free(x);
     basic_free_heap(y);
+    basic_free_stack(x);
 }
 
 void test_complex() {
@@ -101,8 +101,8 @@ void test_complex() {
     SYMENGINE_C_ASSERT(!is_a_Integer(e));
     SYMENGINE_C_ASSERT(is_a_Complex(e));
 
-    basic_free(e);
-    basic_free(f);
+    basic_free_stack(e);
+    basic_free_stack(f);
 }
 
 void test_CVectorInt1()
@@ -159,8 +159,8 @@ void test_CVecBasic()
     SYMENGINE_C_ASSERT(basic_eq(x, y));
 
     vecbasic_free(vec);
-    basic_free(x);
-    basic_free(y);
+    basic_free_stack(x);
+    basic_free_stack(y);
 }
 
 void test_CSetBasic()
@@ -195,8 +195,8 @@ void test_CSetBasic()
     SYMENGINE_C_ASSERT(basic_eq(x, y));
 
     setbasic_free(set);
-    basic_free(x);
-    basic_free(y);
+    basic_free_stack(x);
+    basic_free_stack(y);
 }
 
 void test_get_args()
@@ -220,10 +220,10 @@ void test_get_args()
     SYMENGINE_C_ASSERT(vecbasic_size(args) == 3);
     vecbasic_free(args);
 
-    basic_free(e);
-    basic_free(x);
-    basic_free(y);
-    basic_free(z);
+    basic_free_stack(e);
+    basic_free_stack(x);
+    basic_free_stack(y);
+    basic_free_stack(z);
 }
 
 void test_free_symbols()
@@ -247,10 +247,10 @@ void test_free_symbols()
     SYMENGINE_C_ASSERT(setbasic_size(symbols) == 3);
     setbasic_free(symbols);
 
-    basic_free(e);
-    basic_free(x);
-    basic_free(y);
-    basic_free(z);
+    basic_free_stack(e);
+    basic_free_stack(x);
+    basic_free_stack(y);
+    basic_free_stack(z);
 }
 
 void test_get_type() {
@@ -263,8 +263,8 @@ void test_get_type() {
     SYMENGINE_C_ASSERT(basic_get_type(x) == SYMENGINE_SYMBOL);
     SYMENGINE_C_ASSERT(basic_get_type(y) == SYMENGINE_INTEGER);
 
-    basic_free(x);
-    basic_free(y);
+    basic_free_stack(x);
+    basic_free_stack(y);
 }
 
 void test_hash() {
@@ -279,9 +279,9 @@ void test_hash() {
     SYMENGINE_C_ASSERT(basic_hash(x1) == basic_hash(x2));
     if (basic_hash(x1) != basic_hash(y)) SYMENGINE_C_ASSERT(basic_neq(x1,y));
 
-    basic_free(x1);
-    basic_free(x2);
-    basic_free(y);
+    basic_free_stack(x1);
+    basic_free_stack(x2);
+    basic_free_stack(y);
 }
 
 int main(int argc, char* argv[])

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -9,9 +9,9 @@
 void test_cwrapper() {
     char* s;
     basic x, y, z;
-    basic_init(x);
-    basic_init(y);
-    basic_init(z);
+    basic_new_stack(x);
+    basic_new_stack(y);
+    basic_new_stack(z);
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -20,7 +20,7 @@ void test_cwrapper() {
     SYMENGINE_C_ASSERT(strcmp(s, "x") == 0);
     basic_str_free(s);
     basic e;
-    basic_init(e);
+    basic_new_stack(e);
 
     integer_set_ui(e, 123);
     s = basic_str(e);
@@ -70,7 +70,7 @@ void test_cwrapper() {
 
 void test_basic() {
     basic x;
-    basic_init(x);
+    basic_new_stack(x);
     symbol_set(x, "x");
 
     basic_struct *y = basic_new_heap();
@@ -87,8 +87,8 @@ void test_complex() {
     basic e;
     basic f;
     char* s;
-    basic_init(e);
-    basic_init(f);
+    basic_new_stack(e);
+    basic_new_stack(f);
     rational_set_ui(e, 100, 47);
     rational_set_ui(f, 76, 59);
     complex_set(e, e, f);
@@ -146,14 +146,14 @@ void test_CVecBasic()
     SYMENGINE_C_ASSERT(vecbasic_size(vec) == 0);
 
     basic x;
-    basic_init(x);
+    basic_new_stack(x);
     symbol_set(x, "x");
     vecbasic_push_back(vec, x);
 
     SYMENGINE_C_ASSERT(vecbasic_size(vec) == 1);
 
     basic y;
-    basic_init(y);
+    basic_new_stack(y);
     vecbasic_get(vec, 0, y);
 
     SYMENGINE_C_ASSERT(basic_eq(x, y));
@@ -169,7 +169,7 @@ void test_CSetBasic()
     SYMENGINE_C_ASSERT(setbasic_size(set) == 0);
 
     basic x;
-    basic_init(x);
+    basic_new_stack(x);
     symbol_set(x, "x");
 
     int has_insert;
@@ -181,7 +181,7 @@ void test_CSetBasic()
     SYMENGINE_C_ASSERT(has_insert == 0);
 
     basic y;
-    basic_init(y);
+    basic_new_stack(y);
     symbol_set(y, "y");
 
     int is_found;
@@ -202,10 +202,10 @@ void test_CSetBasic()
 void test_get_args()
 {
     basic x, y, z, e;
-    basic_init(x);
-    basic_init(y);
-    basic_init(z);
-    basic_init(e);
+    basic_new_stack(x);
+    basic_new_stack(y);
+    basic_new_stack(z);
+    basic_new_stack(e);
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -229,10 +229,10 @@ void test_get_args()
 void test_free_symbols()
 {
     basic x, y, z, e;
-    basic_init(x);
-    basic_init(y);
-    basic_init(z);
-    basic_init(e);
+    basic_new_stack(x);
+    basic_new_stack(y);
+    basic_new_stack(z);
+    basic_new_stack(e);
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -255,8 +255,8 @@ void test_free_symbols()
 
 void test_get_type() {
     basic x, y;
-    basic_init(x);
-    basic_init(y);
+    basic_new_stack(x);
+    basic_new_stack(y);
     symbol_set(x, "x");
     integer_set_ui(y, 123);
 
@@ -269,9 +269,9 @@ void test_get_type() {
 
 void test_hash() {
     basic x1, x2, y;
-    basic_init(x1);
-    basic_init(x2);
-    basic_init(y);
+    basic_new_stack(x1);
+    basic_new_stack(x2);
+    basic_new_stack(y);
     symbol_set(x1, "x");
     symbol_set(x2, "x");
     symbol_set(y, "y");


### PR DESCRIPTION
This makes the functions consistent with `basic_new_heap()` and `basic_free_heap()`. Documentation was improved to explain this issue.