### PR TITLE
Updated the beginner notebook and added example notebook

### DIFF
--- a/symengine/ruby/notebooks/beginner.ipynb
+++ b/symengine/ruby/notebooks/beginner.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -22,7 +22,7 @@
        "true"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -50,8 +50,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      " _____           _____         _         \n",
-      "|   __|_ _ _____|   __|___ ___|_|___ ___ \n",
+      " _____           _____         _\n",
+      "|   __|_ _ _____|   __|___ ___|_|___ ___\n",
       "|__   | | |     |   __|   | . | |   | -_|\n",
       "|_____|_  |_|_|_|_____|_|_|_  |_|_|_|___|\n",
       "      |___|               |___|          \n"
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -79,10 +79,10 @@
     {
      "data": {
       "text/plain": [
-       "#<SymEngine::Basic:0x00000002b09328>"
+       "#<SymEngine::Basic:0x00000001e95290>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -95,72 +95,103 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can even make `Symbol`s and construct expressions out of them"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "z*(x + y)"
-      ],
-      "text/plain": [
-       "#<SymEngine::Symbol:0x00000002add908>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "x = SymEngine::Symbol.new(\"x\")\n",
-    "y = SymEngine::Symbol.new(\"y\")\n",
-    "z = SymEngine::Symbol.new(\"z\")\n",
-    "e = (x+y)*z"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "x*z + y*z"
-      ],
-      "text/plain": [
-       "#<SymEngine::Symbol:0x00000002abac50>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f = e.expand()"
+    "This shows that we have successfully loaded the module."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or check if two expressions are same"
+    "## SymEngine::Symbol\n",
+    "Just like there are variables like x, y, and z in a mathematical expression or equation, we have `SymEngine::Symbol` in SymEngine to represent them. To use a variable, first we need to make a `SymEngine::Symbol` object with the string we are going to represent the variable with."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x\n",
+      "y\n",
+      "z\n"
+     ]
+    }
+   ],
+   "source": [
+    "puts x = SymEngine::Symbol.new(\"x\")\n",
+    "puts y = SymEngine::Symbol.new(\"y\")\n",
+    "puts z = SymEngine::Symbol.new(\"z\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can construct expressions out of them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"x**y*(x - y)/z\""
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "e = (x-y)*(x**y/z)\n",
+    "e.to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In SymEngine, every object is an instance of Basic or its subclasses. So, even an instance of `SymEngine::Symbol` is a Basic object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SymEngine::Symbol"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -171,20 +202,50 @@
        "true"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f == x*z + y*z"
+    "x.is_a? SymEngine::Basic"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But `e` and `f` are not equal since they are only mathematically equal, not structurally"
+    "Now that we have an expression, we would like to see it's expanded form using `#expand`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"x**(1 + y)/z - x**y*y/z\""
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f = e.expand()\n",
+    "f.to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or check if two expressions are same"
    ]
   },
   {
@@ -197,7 +258,7 @@
     {
      "data": {
       "text/plain": [
-       "false"
+       "true"
       ]
      },
      "execution_count": 8,
@@ -206,7 +267,352 @@
     }
    ],
    "source": [
+    "f == - (x**y*y/z) + (x**y*x/z)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But `e` and `f` are not equal since they are only mathematically equal, not structurally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "e == f"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us suppose you want to know **what variables/symbols your expression has**. You can do that with the `#free_symbols` method. The method `#free_symbols` returns a `Set` of the symbols that are in an expression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "#<Set: {#<SymEngine::Basic:0x00000001f0ca70>, #<SymEngine::Basic:0x00000001f0ca48>, #<SymEngine::Basic:0x00000001f0ca20>}>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.free_symbols"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us use `#map` method to see the elements of the `Set`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"x\", \"y\", \"z\"]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.free_symbols.map { |x| x.to_s }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`#args` returns the terms of the expression,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"-x**y*y/z\", \"x**(1 + y)/z\"]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.args.map { |x| x.to_s }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or if it is a single term it breaks down the elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"-1\", \"x**y\", \"y\", \"z**(-1)\"]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.args[0].args.map { |k| k.to_s }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SymEngine::Integer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can make objects of class `SymEngine::Integer`. It's like regular `Integer` in ruby kernel, except it can do all the operations a `Basic` object can like arithmetic operations, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "1168422057627266461843148138873451659428421700563161428957815831003136"
+      ],
+      "text/plain": [
+       "#<SymEngine::Integer:0x00000001dd90e0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a = SymEngine::Integer.new(12)\n",
+    "b = SymEngine::Integer.new(64)\n",
+    "a**b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And yes it can support numbers of arbitrarily large length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"12**x\""
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(a**x).to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SymEngine::Rational"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also make objects of class `SymEngine::Rational` that is the SymEngine counterpart for `Rationals` in Ruby."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "2/3"
+      ],
+      "text/plain": [
+       "#<SymEngine::Rational:0x00000001d89900>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c = Rational('2/3')\n",
+    "d = SymEngine::Rational.new(c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Like any other `Basic` object arithmetic operations can be done on this one too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"34/3\""
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(a-d).to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "You **need not create** an instance of `SymEngine::Integer` or `SymEngine::Rational`, every time you want to use them in an expression that uses many `Integer`s. Let us say you already have `Integer`/`Rational` object. Even then you can use them without having to create a new `SymEngine` object. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"(2/3 + x*y)*(2 + 1/(x*y) - x*y)\""
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k = (1 / (x * y) - x * y + 2) * (c + x * y) # c is a Rational object, not SymEngine::Rational\n",
+    "k.to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, ruby kernel `Integer`s and `Rational`s interoperate seamlessly with the `SymEngine` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"7/3 + (2/3)*1/(x*y) + (4/3)*x*y - x**2*y**2\""
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k.expand.to_s"
    ]
   }
  ],

--- a/symengine/ruby/notebooks/differentiation_example.ipynb
+++ b/symengine/ruby/notebooks/differentiation_example.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Differentiation example\n",
+    "This demonstrates solving the problem I found [here](http://math.stackexchange.com/questions/221197/a-tough-differential-calculus-problem), using the *SymEngine* gem.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function is described as \n",
+    "$$f_p(x) = \\dfrac{9\\sqrt{x^2+p}}{x^2+2}$$\n",
+    "We need to differentiate w.r.t. $x$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One solution is:\n",
+    "$$f_p^2(x) (x^2 + 2)^2 = 81(x^2 + p) \\quad\\Longrightarrow$$\n",
+    "\n",
+    "$$2 f_p(x) f_p'(x)(x^2 + 2)^2 + 4x f_p^2(x^2 +2) = 162x \\quad\\Longrightarrow$$\n",
+    "\n",
+    "\\begin{align}f_p'(x) &= \\frac{162x - 4x f_p^2(x)(x^2+2)}{2f_p(x)(x^2+2)^2}\\\\ \\\\ &= \\frac{162x - 324x\\frac{x^2 + p}{x^2 +2}}{18(x^2 +2)\\sqrt{x^2+p}}\\\\ \\\\ &= \\frac{9 x (x^2+2) - 18x(x^2+p)}{(x^2 + 2)^2 \\sqrt{x^2 + p}}\\\\ \\\\ &= \\frac{9x(2-2p-x^2)}{(x^2 + 2)^2\\sqrt{x^2 + p}}\\end{align}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will attempt to solve this using features in *SymEngine*\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "require 'symengine'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Declare the symbols"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1/2)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = SymEngine::Symbol.new('x')\n",
+    "p = SymEngine::Symbol.new('p')\n",
+    "half = Rational('1/2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the expression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"9*(p + x**2)**(1/2)/(2 + x**2)\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fp = 9*((x**2 + p)**half)/((x**2)+2)\n",
+    "fp.to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Differentiate wrt $x$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"-18*x*(p + x**2)**(1/2)/(2 + x**2)**2 + 9*x/((2 + x**2)*(p + x**2)**(1/2))\""
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "answer = fp.diff(x)\n",
+    "answer.to_s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which is indeed correct! If you simplify the second last answer that we got from our solution. You will find the exact same answer. Using *SymEngine* for solving problems is as simple as that."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Ruby 2.2.0",
+   "language": "ruby",
+   "name": "ruby"
+  },
+  "language_info": {
+   "file_extension": "rb",
+   "mimetype": "application/x-ruby",
+   "name": "ruby",
+   "version": "2.2.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
I had to add `#to_s` method to the output of every expression to display the output. They are just a temporary workaround. The fact that the `Add`, `Mul` and `Pow` are now converted to `SymEngine::Basic` seems to have broken the expected behaviour of the `#to_iruby` method. I had so written the `#to_iruby` method, that it avoided the instances of purely `Basic` class, since they are uninitialised and cause an error. I will remove them after they(Add/Mul/Pow) are properly represented in Ruby.