### PR TITLE
Install Sage from a tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,12 +135,10 @@ matrix:
     - env: BUILD_TYPE="Release" WITH_SAGE="yes" WITH_PYTHON="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
-      sudo: true
   allow_failures:
     - env: BUILD_TYPE="Release" WITH_SAGE="yes" WITH_PYTHON="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
-      sudo: true
 
 install:
   - source bin/install_travis.sh

--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -90,16 +90,8 @@ if [[ "${WITH_PYTHON}" == "yes" && "${WITH_SAGE}" != "yes" || "${PYTHON_INSTALL}
     source activate test-environment;
 fi
 if [[ "${WITH_SAGE}" == "yes" ]]; then
-    sudo apt-add-repository -y ppa:aims/sagemath;
-    sudo apt-get update;
-    set +e;
-    function install_sage {
-        sudo dpkg --configure -a;
-        sudo apt-get install sagemath-upstream-binary;
-    };
-    travis_retry install_sage;
-    set -e;
-
+    wget -O- http://files.sagemath.org/linux/64bit/sage-6.8-x86_64-Linux-Ubuntu_12.04_64_bit.tar.gz | tar xz
+    export PATH="`pwd`/sage-6.8-x86_64-Linux:$PATH"
     SAGE_ROOT=$(sage -python << EOF
 import os
 print os.environ['SAGE_ROOT']


### PR DESCRIPTION
@isuruf this works with `sudo: false` and it avoids saving the tarball. Here is a successful run: https://travis-ci.org/certik/symengine/jobs/75348011

The tarball itself is pretty big, since I use the tar.gz tarball, but as the next iteration, we can figure out how to use the lrzip tarball, which is 2x smaller --- I implemented it in #588, but that issue depends on Travis whitelisting `lrzip`, so for now if this PR works, I would suggest to merge it and we can improve upon it later.