### PR TITLE
Move the Sage test into "cannot fail" section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,10 +149,6 @@ matrix:
     - env: BUILD_TYPE="Release" WITH_SAGE="yes" WITH_PYTHON="yes" WITH_MPC="yes"
       compiler: gcc
       os: linux
-  allow_failures:
-    - env: BUILD_TYPE="Release" WITH_SAGE="yes" WITH_PYTHON="yes" WITH_MPC="yes"
-      compiler: gcc
-      os: linux
 
 install:
   - source bin/install_travis.sh


### PR DESCRIPTION
It seems this test has never failed, so we should just always run it.