### PR TITLE
PEP 3149

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ if use_distutils is not None:
               format(use_distutils))
 
 from distutils.command.build import build as _build
+from distutils.sysconfig import get_config_vars
 
 if use_setuptools:
     try:
@@ -101,6 +102,8 @@ class InstallWithCmake(_install):
 package_dir = 'symengine/python/symengine' if path.exists(path.join(path.dirname(path.realpath(__file__)),
               'symengine/python/symengine')) else 'symengine'
 
+wrapper_extension = get_config_vars().get('EXT_SUFFIX', '.so')
+
 long_description = '''
 SymEngine is a standalone fast C++ symbolic manipulation library.
 Optional thin Python wrappers (SymEngine) allow easy usage from Python and
@@ -116,7 +119,7 @@ setup(name = "symengine",
       url = "https://github.com/sympy/symengine",
       package_dir = {'symengine': package_dir},
       packages=['symengine', 'symengine.lib', 'symengine.tests'],
-      package_data= {'symengine' : ['lib/symengine_wrapper.so']},
+      package_data= {'symengine' : ['lib/symengine_wrapper' + wrapper_extension]},
       cmdclass={
           'build' : BuildWithCmake,
           'install' : InstallWithCmake,

--- a/symengine/python/cmake/FindPython.cmake
+++ b/symengine/python/cmake/FindPython.cmake
@@ -52,6 +52,21 @@ set(PYTHON_INSTALL_PATH ${PYTHON_INSTALL_PATH_tmp}
     CACHE BOOL "Python install path")
 message(STATUS "Python install path: ${PYTHON_INSTALL_PATH}")
 
+if (NOT WIN32)
+    execute_process(
+        COMMAND ${PYTHON_BIN} -c "from distutils.sysconfig import get_config_var; print(get_config_var('SOABI'))"
+        OUTPUT_VARIABLE PYTHON_EXTENSION_SOABI_tmp
+        )
+    string(STRIP ${PYTHON_EXTENSION_SOABI_tmp} PYTHON_EXTENSION_SOABI_tmp)
+    if (NOT "${PYTHON_EXTENSION_SOABI_tmp}" STREQUAL "None")
+        set(PYTHON_EXTENSION_SOABI_tmp ".${PYTHON_EXTENSION_SOABI_tmp}")
+    else()
+        set(PYTHON_EXTENSION_SOABI_tmp "")
+    endif()
+endif()
+set(PYTHON_EXTENSION_SOABI ${PYTHON_EXTENSION_SOABI_tmp}
+    CACHE STRING "Suffix for python extensions")
+
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(PYTHON DEFAULT_MSG PYTHON_LIBRARY PYTHON_INCLUDE_PATH PYTHON_INSTALL_PATH)
 
@@ -99,6 +114,7 @@ macro(ADD_PYTHON_LIBRARY name)
         add_library(${name} SHARED ${ARGN})
     ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(${name} PROPERTIES PREFIX "")
+    set_target_properties(${name} PROPERTIES OUTPUT_NAME "${name}${PYTHON_EXTENSION_SOABI}")
     target_link_libraries(${name} ${PYTHON_LIBRARY})
     IF(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         set_target_properties(${name} PROPERTIES SUFFIX ".pyd")


### PR DESCRIPTION
Fixes #604 

This PR changes the name of the python wrappers according to PEP 3149 when the variable `get_config_var('SOABI')` is defined on non-Windows systems.

cc @bjodah