### PR TITLE
Added conda recipe stub.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ symengine/python/symengine/lib/config.pxi
 
 # Python build files
 build*
+!conda-recipe/build.sh
 *__pycache__*
 *.pyc
 

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release -DWITH_PYTHON=yes -DPYTHON_BIN=$PYTHON ..
+make install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: symengine
+  version: "0.1.1"
+
+source:
+  path: ../
+
+requirements:
+  run:
+    - python
+    - gmp
+    - mpfr
+  build:
+    - cmake
+    - python
+    - gmp
+    - mpfr
+
+test:
+  requires:
+    - cmake
+    - pytest
+
+about:
+  home: https://github.com/sympy/symengine
+  license: BSD
+  summary: 'SymEngine is a fast symbolic manipulation library, written in C++'

--- a/conda-recipe/run_test.py
+++ b/conda-recipe/run_test.py
@@ -1,0 +1,2 @@
+import pytest
+pytest.main(['--pyargs', 'symengine'])


### PR DESCRIPTION
Currently this is failing due to missing binutils, which is surprising since I didn't set `-DWITH_BDF=yes`


```
[ 53%] Building CXX object symengine/tests/rcp/CMakeFiles/test_rcp.dir/test_rcp.cpp.o
Linking CXX executable test_rcp
../../teuchos/libteuchos.a(Teuchos_stacktrace.cpp.o): In function `(anonymous namespace)::addr2str(std::string, unsigned long)':
Teuchos_stacktrace.cpp:(.text+0x7b4): undefined reference to `bfd_openr'
Teuchos_stacktrace.cpp:(.text+0x7cd): undefined reference to `bfd_check_format'
Teuchos_stacktrace.cpp:(.text+0x7ea): undefined reference to `bfd_check_format_matches'
Teuchos_stacktrace.cpp:(.text+0x97a): undefined reference to `bfd_map_over_sections'
Teuchos_stacktrace.cpp:(.text+0x994): undefined reference to `bfd_close'
../../teuchos/libteuchos.a(Teuchos_stacktrace.cpp.o): In function `(anonymous namespace)::stacktrace2str((anonymous namespace)::StacktraceAddresses const&)':
Teuchos_stacktrace.cpp:(.text+0x1fbc): undefined reference to `bfd_init'
collect2: error: ld returned 1 exit status
make[2]: *** [symengine/tests/rcp/test_rcp] Error 1
make[1]: *** [symengine/tests/rcp/CMakeFiles/test_rcp.dir/all] Error 2
make: *** [all] Error 2
```